### PR TITLE
ConfigFileCredentialProvider resolves tilde to posix home directory instead of sandboxed filesyste,

### DIFF
--- a/Sources/AWSSDKSwiftCore/Credential/ConfigFileCredentialProvider.swift
+++ b/Sources/AWSSDKSwiftCore/Credential/ConfigFileCredentialProvider.swift
@@ -19,7 +19,11 @@ import NIO
 #if os(Linux)
 import Glibc
 #else
+#if os(macOS)
+import Foundation
+#else
 import Foundation.NSString
+#endif
 #endif
 
 struct AWSConfigFileCredentialProvider: CredentialProvider {
@@ -134,7 +138,15 @@ struct AWSConfigFileCredentialProvider: CredentialProvider {
             return pth
         }
         #else
+        #if os(macOS)
+        let pw = getpwuid(getuid())
+        let home = pw?.pointee.pw_dir
+        let homePath = FileManager.default.string(withFileSystemRepresentation: home!, length: Int(strlen(home!)))
+        let expandedPath = filePath.replacingOccurrences(of: "~", with: homePath)
+        return expandedPath
+        #else
         return NSString(string: filePath).expandingTildeInPath
+        #endif
         #endif
     }
 }

--- a/Sources/AWSSDKSwiftCore/Credential/ConfigFileCredentialProvider.swift
+++ b/Sources/AWSSDKSwiftCore/Credential/ConfigFileCredentialProvider.swift
@@ -139,9 +139,8 @@ struct AWSConfigFileCredentialProvider: CredentialProvider {
         }
         #else
         #if os(macOS)
-        let pw = getpwuid(getuid())
-        let home = pw?.pointee.pw_dir
-        let homePath = FileManager.default.string(withFileSystemRepresentation: home!, length: Int(strlen(home!)))
+        guard let pw = getpwuid(getuid()) else { return filePath }
+        let homePath = FileManager.default.string(withFileSystemRepresentation: pw.pointee.pw_dir, length: Int(strlen(pw.pointee.pw_dir)))
         let expandedPath = filePath.replacingOccurrences(of: "~", with: homePath)
         return expandedPath
         #else

--- a/Tests/AWSSDKSwiftCoreTests/Credential/ConfigFileCredentialProviderTests.swift
+++ b/Tests/AWSSDKSwiftCoreTests/Credential/ConfigFileCredentialProviderTests.swift
@@ -128,6 +128,15 @@ class ConfigFileCredentialProviderTests: XCTestCase {
         #if os(Linux)
         XCTAssert(!expandedNewPath.hasPrefix("~"))
         #else
+
+        #if os(macOS)
+        // on macOS, we want to be sure the expansion produces the posix $HOME and
+        // not the sanboxed home $HOME/Library/Containers/<bundle-id>/Data
+        let macOSHomePrefix = "/Users/"
+        XCTAssert(expandedNewPath.starts(with: macOSHomePrefix))
+        XCTAssert(!expandedNewPath.contains("/Library/Containers/"))
+        #endif
+
         // this doesn't work on linux because of SR-12843
         let expandedNSString = NSString(string: expandableFilePath).expandingTildeInPath
         XCTAssertEqual(expandedNewPath, expandedNSString)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the AWSSDKSwift open source project
+##
+## Copyright (c) 2020 the AWSSDKSwift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+# start a native build
+swift build

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -18,6 +18,8 @@ SWIFT_VERSION=5.1
 set -eu
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+which swiftformat > /dev/null 2>&1 || (echo "swiftformat not installed. You can install it using 'brew install swiftformat'" ; exit -1)
+
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
     sed -e 's/20[12][78901]-20[12][8901]/YEARS/' -e 's/20[12][8901]/YEARS/' -e '/^#!/ d'

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the AWSSDKSwift open source project
+##
+## Copyright (c) 2020 the AWSSDKSwift project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.txt for the list of AWSSDKSwift project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+WORKING_DIR=../working
+
+# check if working directory exists and create it if necessary 
+[ ! -d $WORKING_DIR ] && mkdir $WORKING_DIR
+
+# run the test on docker containers
+docker-compose -f docker/docker-compose.yml up


### PR DESCRIPTION
This PR changes `Sources/AWSSDKSwiftCore/Credential/ConfigFileCredentialProvider.swift` to fix https://github.com/swift-aws/aws-sdk-swift-core/issues/359
I updated the corresponding test `Tests/AWSSDKSwiftCoreTests/Credential/ConfigFileCredentialProviderTests.swift`

Two other commits are part of this PR 
- `sanity.sh` : I added a line to verify if `swiftformat` is installed or not and provide installation instruction 
- I added two very simple `build.sh`and `test.sh`to help newcomers to get started