### PR TITLE
macOS tilde expansion in path for sandboxed app

### DIFF
--- a/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
@@ -140,7 +140,7 @@ struct AWSConfigFileCredentialProvider: CredentialProvider {
         else {
             return filePath
         }
-        return filePath.replacingOccurrences(of: "~", with: homePath)
+        return filePath.starts(with: "~") ? homePath + filePath.dropFirst() : filePath
         #else
         return NSString(string: filePath).expandingTildeInPath
         #endif

--- a/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
@@ -133,17 +133,16 @@ struct AWSConfigFileCredentialProvider: CredentialProvider {
 
             return pth
         }
-        #else
-        #if os(macOS)
-        guard let home = getpwuid(getuid())?.pointee.pw_dir else {
+        #elseif os(macOS)
+        // can not use wordexp on macOS because for sandboxed application wexp.we_wordv == nil
+        guard let home = getpwuid(getuid())?.pointee.pw_dir,
+            let homePath = String(cString: home, encoding: .utf8)
+        else {
             return filePath
         }
-        let homePath = FileManager.default.string(withFileSystemRepresentation: home, length: Int(strlen(home)))
-        let expandedPath = filePath.replacingOccurrences(of: "~", with: homePath)
-        return expandedPath
+        return filePath.replacingOccurrences(of: "~", with: homePath)
         #else
         return NSString(string: filePath).expandingTildeInPath
-        #endif
         #endif
     }
 }

--- a/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
@@ -134,7 +134,16 @@ struct AWSConfigFileCredentialProvider: CredentialProvider {
             return pth
         }
         #else
+        #if os(macOS)
+        guard let home = getpwuid(getuid())?.pointee.pw_dir else {
+            return filePath
+        }
+        let homePath = FileManager.default.string(withFileSystemRepresentation: home, length: Int(strlen(home)))
+        let expandedPath = filePath.replacingOccurrences(of: "~", with: homePath)
+        return expandedPath
+        #else
         return NSString(string: filePath).expandingTildeInPath
+        #endif
         #endif
     }
 }

--- a/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
@@ -128,6 +128,15 @@ class ConfigFileCredentialProviderTests: XCTestCase {
         #if os(Linux)
         XCTAssert(!expandedNewPath.hasPrefix("~"))
         #else
+
+        #if os(macOS)
+        // on macOS, we want to be sure the expansion produces the posix $HOME and
+        // not the sanboxed home $HOME/Library/Containers/<bundle-id>/Data
+        let macOSHomePrefix = "/Users/"
+        XCTAssert(expandedNewPath.starts(with: macOSHomePrefix))
+        XCTAssert(!expandedNewPath.contains("/Library/Containers/"))
+        #endif
+
         // this doesn't work on linux because of SR-12843
         let expandedNSString = NSString(string: expandableFilePath).expandingTildeInPath
         XCTAssertEqual(expandedNewPath, expandedNSString)

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -18,6 +18,8 @@ SWIFT_VERSION=5.1
 set -eu
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+which swiftformat > /dev/null 2>&1 || (echo "swiftformat not installed. You can install it using 'brew install swiftformat'" ; exit -1)
+
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
     sed -e 's/20[12][78901]-20[12][8901]/YEARS/' -e 's/20[12][8901]/YEARS/' -e '/^#!/ d'


### PR DESCRIPTION
As discussed, here is a new PR to address https://github.com/soto-project/soto-core/issues/359

The proposed solution to handle Linux and macOS by just changing [this line](https://github.com/soto-project/soto-core/blob/main/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift#L116) does not work, because when running in a sandboxed app `wexp.we_wordv` is nil.

I revert back to my original solution. Tested on macOS Catalina on both a sanboxed (with appropriate entitlements for file access) and not sandboxed app.


