### PR TITLE
Allow for multiple timestamp formats in TimeStampFormatCoder

### DIFF
--- a/Tests/SotoCoreTests/TimeStampTests.swift
+++ b/Tests/SotoCoreTests/TimeStampTests.swift
@@ -53,6 +53,20 @@ class TimeStampTests: XCTestCase {
         }
     }
 
+    func testDecodeISONoMillisecondFromXML() {
+        do {
+            struct A: Codable {
+                @Coding<ISO8601TimeStampCoder> var date: TimeStamp
+            }
+            let xml = "<A><date>2017-01-01T00:01:00Z</date></A>"
+            let xmlElement = try XML.Element(xmlString: xml)
+            let a = try XMLDecoder().decode(A.self, from: xmlElement)
+            XCTAssertEqual(a.date.stringValue, "2017-01-01T00:01:00.000Z")
+        } catch {
+            XCTFail("\(error)")
+        }
+    }
+
     func testDecodeHttpFormattedTimestamp() {
         do {
             struct A: Codable {


### PR DESCRIPTION
Add additional format for ISO8601TimeStampCoder
This fixes issue with ApiGatewayV2 decoding iso8601 TimeStamps without milliseconds