### PR TITLE
Sign URL with headers

### DIFF
--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -462,21 +462,24 @@ extension AWSClient {
     /// generate a signed URL
     /// - parameters:
     ///     - url : URL to sign
-    ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
+    ///     - httpMethod: HTTP method to use (.GET, .PUT, .PUSH etc)
+    ///     - httpHeaders: Headers that are to be used with this URL. Be sure to include these headers when you used the returned URL
     ///     - expires: How long before the signed URL expires
     ///     - serviceConfig: additional AWS service configuration used to sign the url
+    ///     - logger: Logger to output to
     /// - returns:
     ///     A signed URL
     public func signURL(
         url: URL,
         httpMethod: HTTPMethod,
+        headers: HTTPHeaders = HTTPHeaders(),
         expires: Int = 86400,
         serviceConfig: AWSServiceConfig,
         logger: Logger = AWSClient.loggingDisabled
     ) -> EventLoopFuture<URL> {
         let logger = logger.attachingRequestId(Self.globalRequestID.add(1), operation: "signURL", service: serviceConfig.service)
         return createSigner(serviceConfig: serviceConfig, logger: logger).map { signer in
-            signer.signURL(url: url, method: httpMethod, expires: expires)
+            signer.signURL(url: url, method: httpMethod, headers: headers, expires: expires)
         }
     }
 

--- a/Sources/SotoCore/AWSService.swift
+++ b/Sources/SotoCore/AWSService.swift
@@ -32,11 +32,19 @@ extension AWSService {
     /// generate a signed URL
     /// - parameters:
     ///     - url : URL to sign
-    ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
+    ///     - httpMethod: HTTP method to use (.GET, .PUT, .PUSH etc)
+    ///     - httpHeaders: Headers that are to be used with this URL. Be sure to include these headers when you used the returned URL
     ///     - expires: How long before the signed URL expires
+    ///     - logger: Logger to output to
     /// - returns:
     ///     A signed URL
-    public func signURL(url: URL, httpMethod: HTTPMethod, expires: Int = 86400, logger: Logger = AWSClient.loggingDisabled) -> EventLoopFuture<URL> {
-        return self.client.signURL(url: url, httpMethod: httpMethod, expires: expires, serviceConfig: self.config, logger: logger)
+    public func signURL(
+        url: URL,
+        httpMethod: HTTPMethod,
+        headers: HTTPHeaders = HTTPHeaders(),
+        expires: Int = 86400,
+        logger: Logger = AWSClient.loggingDisabled
+    ) -> EventLoopFuture<URL> {
+        return self.client.signURL(url: url, httpMethod: httpMethod, headers: headers, expires: expires, serviceConfig: self.config, logger: logger)
     }
 }

--- a/Sources/SotoCore/Exports.swift
+++ b/Sources/SotoCore/Exports.swift
@@ -25,3 +25,4 @@
 @_exported import struct NIO.TimeAmount
 
 @_exported import enum NIOHTTP1.HTTPMethod
+@_exported import struct NIOHTTP1.HTTPHeaders

--- a/Sources/SotoCore/Exports.swift
+++ b/Sources/SotoCore/Exports.swift
@@ -24,5 +24,5 @@
 @_exported import protocol NIO.EventLoopGroup
 @_exported import struct NIO.TimeAmount
 
-@_exported import enum NIOHTTP1.HTTPMethod
 @_exported import struct NIOHTTP1.HTTPHeaders
+@_exported import enum NIOHTTP1.HTTPMethod

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -81,8 +81,9 @@ public struct AWSSigner {
     }
 
     /// Generate a signed URL, for a HTTP request
-    public func signURL(url: URL, method: HTTPMethod = .GET, body: BodyData? = nil, date: Date = Date(), expires: Int = 86400) -> URL {
-        let headers = HTTPHeaders([("host", url.host ?? "")])
+    public func signURL(url: URL, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: BodyData? = nil, date: Date = Date(), expires: Int = 86400) -> URL {
+        var headers = headers
+        headers.replaceOrAdd(name: "host", value: url.host ?? "")
         // Create signing data
         var signingData = AWSSigner.SigningData(url: url, method: method, headers: headers, body: body, date: AWSSigner.timestamp(date), signer: self)
         // Construct query string. Start with original query strings and append all the signing info.

--- a/Tests/SotoSignerV4Tests/AWSSignerTests.swift
+++ b/Tests/SotoSignerV4Tests/AWSSignerTests.swift
@@ -66,6 +66,17 @@ final class AWSSignerTests: XCTestCase {
         XCTAssertEqual(url.absoluteString, "https://test-bucket.s3.amazonaws.com/test-put.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=MYACCESSKEY%2F20010102%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20010102T034640Z&X-Amz-Expires=86400&X-Amz-Security-Token=MYSESSIONTOKEN&X-Amz-SignedHeaders=host&X-Amz-Signature=969dfbc450089f34f5b430611b18def1701c72c9e7e1608142051a898094227e")
     }
 
+    func testSignS3PutWithHeaderURL() {
+        let signer = AWSSigner(credentials: credentialsWithSessionKey, name: "s3", region: "eu-west-1")
+        let url = signer.signURL(
+            url: URL(string: "https://test-bucket.s3.amazonaws.com/test-put.txt")!,
+            method: .PUT,
+            headers: ["x-amz-acl": "public-read"],
+            date: Date(timeIntervalSinceReferenceDate: 100_000)
+        )
+        XCTAssertEqual(url.absoluteString, "https://test-bucket.s3.amazonaws.com/test-put.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=MYACCESSKEY%2F20010102%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20010102T034640Z&X-Amz-Expires=86400&X-Amz-Security-Token=MYSESSIONTOKEN&X-Amz-SignedHeaders=host%3Bx-amz-acl&X-Amz-Signature=a849c034af312e8424b3b0dd425e3e21ce7a61641f4b6a84c203b115447309c8")
+    }
+
     func testBodyData() {
         let string = "testing, testing, 1,2,1,2"
         let data = string.data(using: .utf8)!


### PR DESCRIPTION
Allow user to include headers in signed URL.

When the url is used the same headers will need to be supplied to the http client.