### PR TITLE
Rest json error parsing fix

### DIFF
--- a/Sources/SotoCore/Message/AWSResponse.swift
+++ b/Sources/SotoCore/Message/AWSResponse.swift
@@ -215,7 +215,11 @@ public struct AWSResponse {
 
         case .json:
             guard case .json(let data) = self.body else { break }
+            // rest JSON errors come in two formats one "Message" key capitalized and one not
             apiError = try? JSONDecoder().decode(JSONError.self, from: data)
+            if apiError == nil {
+                apiError = try? JSONDecoder().decode(JSONErrorV2.self, from: data)
+            }
 
         case .ec2:
             guard case .xml(var element) = self.body else { break }
@@ -273,6 +277,16 @@ public struct AWSResponse {
         private enum CodingKeys: String, CodingKey {
             case code = "__type"
             case message
+        }
+    }
+
+    private struct JSONErrorV2: Codable, APIError {
+        var code: String?
+        var message: String
+
+        private enum CodingKeys: String, CodingKey {
+            case code = "__type"
+            case message = "Message"
         }
     }
 

--- a/Tests/SotoCoreTests/AWSResponseTests.swift
+++ b/Tests/SotoCoreTests/AWSResponseTests.swift
@@ -218,6 +218,20 @@ class AWSResponseTests: XCTestCase {
         XCTAssertEqual(error as? ServiceErrorType, .resourceNotFoundException(message: "Donald Where's Your Troosers?"))
     }
 
+    func testJSONErrorV2() {
+        let response = AWSHTTPResponseImpl(
+            status: .notFound,
+            headers: HTTPHeaders(),
+            bodyData: "{\"__type\":\"ResourceNotFoundException\", \"Message\": \"Donald Where's Your Troosers?\"}".data(using: .utf8)!
+        )
+        let service = createServiceConfig(serviceProtocol: .json(version: "1.1"), possibleErrorTypes: [ServiceErrorType.self])
+
+        var awsResponse: AWSResponse?
+        XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .json(version: "1.1"), raw: false))
+        let error = awsResponse?.generateError(serviceConfig: service, logger: TestEnvironment.logger)
+        XCTAssertEqual(error as? ServiceErrorType, .resourceNotFoundException(message: "Donald Where's Your Troosers?"))
+    }
+
     func testRestJSONError() {
         let response = AWSHTTPResponseImpl(
             status: .notFound,

--- a/Tests/SotoCoreTests/AWSResponseTests.swift
+++ b/Tests/SotoCoreTests/AWSResponseTests.swift
@@ -218,6 +218,34 @@ class AWSResponseTests: XCTestCase {
         XCTAssertEqual(error as? ServiceErrorType, .resourceNotFoundException(message: "Donald Where's Your Troosers?"))
     }
 
+    func testRestJSONError() {
+        let response = AWSHTTPResponseImpl(
+            status: .notFound,
+            headers: ["x-amzn-errortype": "ResourceNotFoundException"],
+            bodyData: Data("{\"message\": \"Donald Where's Your Troosers?\"}".utf8)
+        )
+        let service = createServiceConfig(serviceProtocol: .restjson, possibleErrorTypes: [ServiceErrorType.self])
+
+        var awsResponse: AWSResponse?
+        XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .restjson, raw: false))
+        let error = awsResponse?.generateError(serviceConfig: service, logger: TestEnvironment.logger)
+        XCTAssertEqual(error as? ServiceErrorType, .resourceNotFoundException(message: "Donald Where's Your Troosers?"))
+    }
+
+    func testRestJSONErrorV2() {
+        let response = AWSHTTPResponseImpl(
+            status: .notFound,
+            headers: ["x-amzn-errortype": "ResourceNotFoundException"],
+            bodyData: Data("{\"Message\": \"Donald Where's Your Troosers?\"}".utf8)
+        )
+        let service = createServiceConfig(serviceProtocol: .restjson, possibleErrorTypes: [ServiceErrorType.self])
+
+        var awsResponse: AWSResponse?
+        XCTAssertNoThrow(awsResponse = try AWSResponse(from: response, serviceProtocol: .restjson, raw: false))
+        let error = awsResponse?.generateError(serviceConfig: service, logger: TestEnvironment.logger)
+        XCTAssertEqual(error as? ServiceErrorType, .resourceNotFoundException(message: "Donald Where's Your Troosers?"))
+    }
+
     func testXMLError() {
         let response = AWSHTTPResponseImpl(
             status: .notFound,

--- a/Tests/SotoSignerV4Tests/AWSSignerTests.swift
+++ b/Tests/SotoSignerV4Tests/AWSSignerTests.swift
@@ -42,6 +42,12 @@ final class AWSSignerTests: XCTestCase {
         XCTAssertEqual(headers["Authorization"].first, "AWS4-HMAC-SHA256 Credential=MYACCESSKEY/20010124/us-east-1/glacier/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-glacier-version, Signature=acfa9b03fca6b098d7b88bfd9bbdb4687f5b34e944a9c6ed9f4814c1b0b06d62")
     }
 
+    func testSignWithSlashAtEndOfPath() {
+        let signer = AWSSigner(credentials: credentials, name: "sns", region: "eu-central-1")
+        let headers = signer.signHeaders(url: URL(string: "https://sns.eu-central-1.amazonaws.com/topics/")!, method: .GET, date: Date(timeIntervalSinceReferenceDate: 2_000_000))
+        XCTAssertEqual(headers["Authorization"].first, "AWS4-HMAC-SHA256 Credential=MYACCESSKEY/20010124/eu-central-1/sns/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=9c04ae96a2ce8addfa7ce933bf7ddda342f42476bd8cef057d1d25f09fb059c1")
+    }
+
     func testSignPutHeaders() {
         let signer = AWSSigner(credentials: credentials, name: "sns", region: "eu-west-1")
         let headers = signer.signHeaders(url: URL(string: "https://sns.eu-west-1.amazonaws.com/")!, method: .POST, headers: ["Content-Type": "application/x-www-form-urlencoded; charset=utf-8"], body: .string("Action=ListTopics&Version=2010-03-31"), date: Date(timeIntervalSinceReferenceDate: 200))


### PR DESCRIPTION
restjson errors can come in the form 
```
{"message": "there has been a message"}
```
or 
```
{"Message": "there has been a message"}
```
The inconsistent capitalization was meaning the second version wasn't been parsed. This change checks for both 