### PR TITLE
Removes duplicate "/" in InstanceMetaDataServiceProvider request

### DIFF
--- a/Sources/AWSSDKSwiftCore/MetaDataService.swift
+++ b/Sources/AWSSDKSwiftCore/MetaDataService.swift
@@ -204,7 +204,7 @@ struct InstanceMetaDataServiceProvider: MetaDataServiceProvider {
                 let roleName = String(data: response.body, encoding: .utf8) else {
                     throw MetaDataServiceError.couldNotGetInstanceRoleName
             }
-            return "\(InstanceMetaDataServiceProvider.baseURLString)/\(roleName)"
+            return "\(InstanceMetaDataServiceProvider.baseURLString)\(roleName)"
         }.flatMap { uri in
             // request credentials
             return self.request(uri: uri, timeout: 2, eventLoopGroup: eventLoopGroup)


### PR DESCRIPTION
When the InstanceMetaDataServiceProvider requests credentials for
the instance role, the URI contained two subsequent "//" slashes.
This resulted in a `MOVED PERMANENTLY` redirect which was not
followed, and thus failing the request.