### PR TITLE
Replace logger with baggage context for AWSClient

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,14 +27,16 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMajor(from: "2.7.2")),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.2.0")),
+        .package(url: "https://github.com/ktoso/gsoc-swift-baggage-context.git", .branch("simple-is-good-proposal")),
     ],
     targets: [
         .target(name: "SotoCore", dependencies: [
             .byName(name: "SotoSignerV4"),
             .byName(name: "SotoXML"),
             .byName(name: "INIParser"),
-            .product(name: "Logging", package: "swift-log"),
             .product(name: "AsyncHTTPClient", package: "async-http-client"),
+            .product(name: "BaggageContext", package: "swift-context"),
+            .product(name: "Logging", package: "swift-log"),
             .product(name: "Metrics", package: "swift-metrics"),
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
@@ -49,6 +51,7 @@ let package = Package(
         ]),
         .target(name: "SotoTestUtils", dependencies: [
             .byName(name: "SotoCore"),
+            .product(name: "BaggageContext", package: "swift-context"),
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
             .product(name: "NIOFoundationCompat", package: "swift-nio"),

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMajor(from: "2.7.2")),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.2.0")),
-        .package(url: "https://github.com/ktoso/gsoc-swift-baggage-context.git", .branch("simple-is-good-proposal")),
+        .package(url: "https://github.com/slashmo/gsoc-swift-baggage-context.git", .branch("main")),
     ],
     targets: [
         .target(name: "SotoCore", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMajor(from: "2.7.2")),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.2.0")),
-        .package(url: "https://github.com/slashmo/gsoc-swift-baggage-context.git", .branch("main")),
+        .package(url: "https://github.com/slashmo/gsoc-swift-baggage-context.git", from: "0.5.0"),
     ],
     targets: [
         .target(name: "SotoCore", dependencies: [

--- a/Sources/SotoCore/AWSClient+Paginate.swift
+++ b/Sources/SotoCore/AWSClient+Paginate.swift
@@ -37,7 +37,7 @@ extension AWSClient {
         input: Input,
         command: @escaping (Input, Context, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
-        context: Context = AWSClient.emptyContext,
+        context: Context = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
@@ -81,7 +81,7 @@ extension AWSClient {
         command: @escaping (Input, Context, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool>,
-        context: Context = AWSClient.emptyContext,
+        context: Context = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
@@ -126,7 +126,7 @@ extension AWSClient {
         command: @escaping (Input, Context, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool?>,
-        context: Context = AWSClient.emptyContext,
+        context: Context = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {

--- a/Sources/SotoCore/AWSClient+Paginate.swift
+++ b/Sources/SotoCore/AWSClient+Paginate.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BaggageContext
 import Logging
 import NIO
 
@@ -34,17 +35,17 @@ extension AWSClient {
     ///   - onPage: closure called with each block of entries
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
-        command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
+        command: @escaping (Input, Context, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
+        context: Context = AWSClient.emptyContext,
         on eventLoop: EventLoop? = nil,
-        logger: Logger = AWSClient.loggingDisabled,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let promise = eventLoop.makePromise(of: Void.self)
 
         func paginatePart(input: Input) {
-            let responseFuture = command(input, eventLoop, logger)
+            let responseFuture = command(input, context, eventLoop)
                 .flatMap { response in
                     return onPage(response, eventLoop)
                         .map { (rt) -> Void in
@@ -77,18 +78,18 @@ extension AWSClient {
     ///   - onPage: closure called with each block of entries
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
-        command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
+        command: @escaping (Input, Context, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool>,
+        context: Context = AWSClient.emptyContext,
         on eventLoop: EventLoop? = nil,
-        logger: Logger = AWSClient.loggingDisabled,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let promise = eventLoop.makePromise(of: Void.self)
 
         func paginatePart(input: Input) {
-            let responseFuture = command(input, eventLoop, logger)
+            let responseFuture = command(input, context, eventLoop)
                 .flatMap { response in
                     return onPage(response, eventLoop)
                         .map { (rt) -> Void in
@@ -122,18 +123,18 @@ extension AWSClient {
     ///   - onPage: closure called with each block of entries
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
-        command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
+        command: @escaping (Input, Context, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool?>,
+        context: Context = AWSClient.emptyContext,
         on eventLoop: EventLoop? = nil,
-        logger: Logger = AWSClient.loggingDisabled,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let promise = eventLoop.makePromise(of: Void.self)
 
         func paginatePart(input: Input) {
-            let responseFuture = command(input, eventLoop, logger)
+            let responseFuture = command(input, context, eventLoop)
                 .flatMap { response in
                     return onPage(response, eventLoop)
                         .map { (rt) -> Void in

--- a/Sources/SotoCore/AWSClient+Paginate.swift
+++ b/Sources/SotoCore/AWSClient+Paginate.swift
@@ -35,9 +35,9 @@ extension AWSClient {
     ///   - onPage: closure called with each block of entries
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
-        command: @escaping (Input, Context, EventLoop?) -> EventLoopFuture<Output>,
+        command: @escaping (Input, BaggageContext, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
-        context: Context = AWSClient.defaultBaggageContext(),
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
@@ -78,10 +78,10 @@ extension AWSClient {
     ///   - onPage: closure called with each block of entries
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
-        command: @escaping (Input, Context, EventLoop?) -> EventLoopFuture<Output>,
+        command: @escaping (Input, BaggageContext, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool>,
-        context: Context = AWSClient.defaultBaggageContext(),
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
@@ -123,10 +123,10 @@ extension AWSClient {
     ///   - onPage: closure called with each block of entries
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
-        command: @escaping (Input, Context, EventLoop?) -> EventLoopFuture<Output>,
+        command: @escaping (Input, BaggageContext, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool?>,
-        context: Context = AWSClient.defaultBaggageContext(),
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -486,7 +486,7 @@ extension AWSClient {
         httpMethod: HTTPMethod,
         headers: HTTPHeaders = HTTPHeaders(),
         expires: TimeAmount,
-        serviceConfig: AWSServiceConfig,
+        config: AWSServiceConfig,
         context: Context = AWSClient.defaultBaggageContext()
     ) -> EventLoopFuture<URL> {
         var context = context

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -259,7 +259,7 @@ extension AWSClient {
                 )
             },
             execute: { request, eventLoop, logger in
-                return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, logger: logger)
+                return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context)
             },
             processResponse: { _ in
                 return
@@ -299,7 +299,7 @@ extension AWSClient {
                 )
             },
             execute: { request, eventLoop, logger in
-                return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, logger: logger)
+                return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context)
             },
             processResponse: { _ in
                 return
@@ -339,7 +339,7 @@ extension AWSClient {
                 )
             },
             execute: { request, eventLoop, logger in
-                return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, logger: logger)
+                return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context)
             },
             processResponse: { response in
                 return try self.validate(operation: operationName, response: response, serviceConfig: serviceConfig)
@@ -382,7 +382,7 @@ extension AWSClient {
                 )
             },
             execute: { request, eventLoop, logger in
-                return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, logger: logger)
+                return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context)
             },
             processResponse: { response in
                 return try self.validate(operation: operationName, response: response, serviceConfig: serviceConfig)
@@ -427,7 +427,7 @@ extension AWSClient {
                 )
             },
             execute: { request, eventLoop, logger in
-                return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, logger: logger, stream: stream)
+                return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context, stream: stream)
             },
             processResponse: { response in
                 return try self.validate(operation: operationName, response: response, serviceConfig: serviceConfig)

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -62,7 +62,9 @@ public final class AWSClient {
     /// default logger that logs nothing
     public static let loggingDisabled = Logger(label: "AWS-do-not-log", factory: { _ in SwiftLogNoOpLogHandler() })
     /// default baggage context
-    public static let emptyContext = DefaultContext.TODO(logger: loggingDisabled)
+    public static func defaultBaggageContext(file: String = #file, line: UInt = #line) -> Context {
+        return DefaultContext.TODO(logger: loggingDisabled, file: file, line: line)
+    }
 
     static let globalRequestID = NIOAtomic<Int>.makeAtomic(value: 0)
 
@@ -244,7 +246,7 @@ extension AWSClient {
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
         input: Input,
-        context: Context = AWSClient.emptyContext,
+        context: Context = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Void> {
         return execute(
@@ -285,7 +287,7 @@ extension AWSClient {
         path: String,
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
-        context: Context = AWSClient.emptyContext,
+        context: Context = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Void> {
         return execute(
@@ -325,7 +327,7 @@ extension AWSClient {
         path: String,
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
-        context: Context = AWSClient.emptyContext,
+        context: Context = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Output> {
         return execute(
@@ -367,7 +369,7 @@ extension AWSClient {
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
         input: Input,
-        context: Context = AWSClient.emptyContext,
+        context: Context = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Output> {
         return execute(
@@ -411,7 +413,7 @@ extension AWSClient {
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
         input: Input,
-        context: Context = AWSClient.emptyContext,
+        context: Context = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         stream: @escaping AWSHTTPClient.ResponseStream
     ) -> EventLoopFuture<Output> {
@@ -485,7 +487,7 @@ extension AWSClient {
         headers: HTTPHeaders = HTTPHeaders(),
         expires: TimeAmount,
         serviceConfig: AWSServiceConfig,
-        context: Context = AWSClient.emptyContext
+        context: Context = AWSClient.defaultBaggageContext()
     ) -> EventLoopFuture<URL> {
         var context = context
         context.baggage.awsService = config.service

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -258,7 +258,7 @@ extension AWSClient {
                     configuration: serviceConfig
                 )
             },
-            execute: { request, eventLoop, logger in
+            execute: { request, eventLoop, context in
                 return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context)
             },
             processResponse: { _ in
@@ -298,7 +298,7 @@ extension AWSClient {
                     configuration: serviceConfig
                 )
             },
-            execute: { request, eventLoop, logger in
+            execute: { request, eventLoop, context in
                 return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context)
             },
             processResponse: { _ in
@@ -338,7 +338,7 @@ extension AWSClient {
                     configuration: serviceConfig
                 )
             },
-            execute: { request, eventLoop, logger in
+            execute: { request, eventLoop, context in
                 return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context)
             },
             processResponse: { response in
@@ -381,7 +381,7 @@ extension AWSClient {
                     configuration: serviceConfig
                 )
             },
-            execute: { request, eventLoop, logger in
+            execute: { request, eventLoop, context in
                 return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context)
             },
             processResponse: { response in
@@ -426,7 +426,7 @@ extension AWSClient {
                     configuration: serviceConfig
                 )
             },
-            execute: { request, eventLoop, logger in
+            execute: { request, eventLoop, context in
                 return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context, stream: stream)
             },
             processResponse: { response in
@@ -442,7 +442,7 @@ extension AWSClient {
     internal func execute<Output>(
         operation operationName: String,
         createRequest: @escaping () throws -> AWSRequest,
-        execute: @escaping (AWSHTTPRequest, EventLoop, Logger) -> EventLoopFuture<AWSHTTPResponse>,
+        execute: @escaping (AWSHTTPRequest, EventLoop, Context) -> EventLoopFuture<AWSHTTPResponse>,
         processResponse: @escaping (AWSHTTPResponse) throws -> Output,
         config: AWSServiceConfig,
         context: Context,
@@ -463,7 +463,7 @@ extension AWSClient {
                     .createHTTPRequest(signer: signer, byteBufferAllocator: config.byteBufferAllocator)
             }.flatMap { request in
                 return self.invoke(with: config, logger: context.logger) {
-                    execute(request, eventLoop, context.logger)
+                    execute(request, eventLoop, context)
                 }
             }.flatMapThrowing(processResponse)
         return recordRequest(future, service: config.service, operation: operationName, logger: context.logger)

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -258,7 +258,7 @@ extension AWSClient {
                     configuration: serviceConfig
                 )
             },
-            execute: { request, eventLoop, context in
+            execute: { request, context, eventLoop in
                 return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context)
             },
             processResponse: { _ in
@@ -298,7 +298,7 @@ extension AWSClient {
                     configuration: serviceConfig
                 )
             },
-            execute: { request, eventLoop, context in
+            execute: { request, context, eventLoop in
                 return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context)
             },
             processResponse: { _ in
@@ -338,7 +338,7 @@ extension AWSClient {
                     configuration: serviceConfig
                 )
             },
-            execute: { request, eventLoop, context in
+            execute: { request, context, eventLoop in
                 return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context)
             },
             processResponse: { response in
@@ -381,7 +381,7 @@ extension AWSClient {
                     configuration: serviceConfig
                 )
             },
-            execute: { request, eventLoop, context in
+            execute: { request, context, eventLoop in
                 return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context)
             },
             processResponse: { response in
@@ -426,7 +426,7 @@ extension AWSClient {
                     configuration: serviceConfig
                 )
             },
-            execute: { request, eventLoop, context in
+            execute: { request, context, eventLoop in
                 return self.httpClient.execute(request: request, timeout: serviceConfig.timeout, on: eventLoop, context: context, stream: stream)
             },
             processResponse: { response in
@@ -442,7 +442,7 @@ extension AWSClient {
     internal func execute<Output>(
         operation operationName: String,
         createRequest: @escaping () throws -> AWSRequest,
-        execute: @escaping (AWSHTTPRequest, EventLoop, Context) -> EventLoopFuture<AWSHTTPResponse>,
+        execute: @escaping (AWSHTTPRequest, Context, EventLoop) -> EventLoopFuture<AWSHTTPResponse>,
         processResponse: @escaping (AWSHTTPResponse) throws -> Output,
         config: AWSServiceConfig,
         context: Context,
@@ -463,7 +463,7 @@ extension AWSClient {
                     .createHTTPRequest(signer: signer, byteBufferAllocator: config.byteBufferAllocator)
             }.flatMap { request in
                 return self.invoke(with: config, logger: context.logger) {
-                    execute(request, eventLoop, context)
+                    execute(request, context, eventLoop)
                 }
             }.flatMapThrowing(processResponse)
         return recordRequest(future, service: config.service, operation: operationName, logger: context.logger)

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -62,7 +62,7 @@ public final class AWSClient {
     /// default logger that logs nothing
     public static let loggingDisabled = Logger(label: "AWS-do-not-log", factory: { _ in SwiftLogNoOpLogHandler() })
     /// default baggage context
-    public static func defaultBaggageContext(file: String = #file, line: UInt = #line) -> Context {
+    public static func defaultBaggageContext(file: String = #file, line: UInt = #line) -> BaggageContext {
         return DefaultContext.TODO(logger: loggingDisabled, file: file, line: line)
     }
 
@@ -246,7 +246,7 @@ extension AWSClient {
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
         input: Input,
-        context: Context = AWSClient.defaultBaggageContext(),
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Void> {
         return execute(
@@ -287,7 +287,7 @@ extension AWSClient {
         path: String,
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
-        context: Context = AWSClient.defaultBaggageContext(),
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Void> {
         return execute(
@@ -327,7 +327,7 @@ extension AWSClient {
         path: String,
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
-        context: Context = AWSClient.defaultBaggageContext(),
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Output> {
         return execute(
@@ -369,7 +369,7 @@ extension AWSClient {
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
         input: Input,
-        context: Context = AWSClient.defaultBaggageContext(),
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Output> {
         return execute(
@@ -413,7 +413,7 @@ extension AWSClient {
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
         input: Input,
-        context: Context = AWSClient.defaultBaggageContext(),
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         stream: @escaping AWSHTTPClient.ResponseStream
     ) -> EventLoopFuture<Output> {
@@ -444,10 +444,10 @@ extension AWSClient {
     internal func execute<Output>(
         operation operationName: String,
         createRequest: @escaping () throws -> AWSRequest,
-        execute: @escaping (AWSHTTPRequest, Context, EventLoop) -> EventLoopFuture<AWSHTTPResponse>,
+        execute: @escaping (AWSHTTPRequest, BaggageContext, EventLoop) -> EventLoopFuture<AWSHTTPResponse>,
         processResponse: @escaping (AWSHTTPResponse) throws -> Output,
         config: AWSServiceConfig,
-        context: Context,
+        context: BaggageContext,
         on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
@@ -487,7 +487,7 @@ extension AWSClient {
         headers: HTTPHeaders = HTTPHeaders(),
         expires: TimeAmount,
         config: AWSServiceConfig,
-        context: Context = AWSClient.defaultBaggageContext()
+        context: BaggageContext = AWSClient.defaultBaggageContext()
     ) -> EventLoopFuture<URL> {
         var context = context
         context.baggage.awsService = config.service
@@ -499,7 +499,7 @@ extension AWSClient {
         }
     }
 
-    func createSigner(config: AWSServiceConfig, context: Context) -> EventLoopFuture<AWSSigner> {
+    func createSigner(config: AWSServiceConfig, context: BaggageContext) -> EventLoopFuture<AWSSigner> {
         return credentialProvider.getCredential(on: eventLoopGroup.next(), logger: context.logger).map { credential in
             return AWSSigner(credentials: credential, name: config.signingName, region: config.region.rawValue)
         }

--- a/Sources/SotoCore/AWSService.swift
+++ b/Sources/SotoCore/AWSService.swift
@@ -46,9 +46,9 @@ extension AWSService {
         httpMethod: HTTPMethod,
         headers: HTTPHeaders = HTTPHeaders(),
         expires: TimeAmount,
-        logger: Logger = AWSClient.loggingDisabled
+        context: Context
     ) -> EventLoopFuture<URL> {
-        return self.client.signURL(url: url, httpMethod: httpMethod, headers: headers, expires: expires, serviceConfig: self.config, logger: logger)
+        return self.client.signURL(url: url, httpMethod: httpMethod, headers: headers, config: self.config, context: context, expires: expires)
     }
 
     /// Return new version of Service with edited parameters

--- a/Sources/SotoCore/AWSService.swift
+++ b/Sources/SotoCore/AWSService.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BaggageContext
 import struct Foundation.URL
-import NIO
 
 public protocol AWSService {
     /// client used to communicate with AWS

--- a/Sources/SotoCore/AWSService.swift
+++ b/Sources/SotoCore/AWSService.swift
@@ -48,7 +48,7 @@ extension AWSService {
         expires: TimeAmount,
         context: Context
     ) -> EventLoopFuture<URL> {
-        return self.client.signURL(url: url, httpMethod: httpMethod, headers: headers, config: self.config, context: context, expires: expires)
+        return self.client.signURL(url: url, httpMethod: httpMethod, headers: headers, expires: expires, config: self.config, context: context)
     }
 
     /// Return new version of Service with edited parameters

--- a/Sources/SotoCore/AWSService.swift
+++ b/Sources/SotoCore/AWSService.swift
@@ -46,7 +46,7 @@ extension AWSService {
         httpMethod: HTTPMethod,
         headers: HTTPHeaders = HTTPHeaders(),
         expires: TimeAmount,
-        context: Context
+        context: BaggageContext
     ) -> EventLoopFuture<URL> {
         return self.client.signURL(url: url, httpMethod: httpMethod, headers: headers, expires: expires, config: self.config, context: context)
     }

--- a/Sources/SotoCore/Baggage.swift
+++ b/Sources/SotoCore/Baggage.swift
@@ -55,6 +55,5 @@ extension Baggage {
         set {
             self[_key: RequestIdKey.self] = newValue
         }
-
     }
 }

--- a/Sources/SotoCore/Baggage.swift
+++ b/Sources/SotoCore/Baggage.swift
@@ -16,44 +16,44 @@ import Baggage
 
 private enum RequestIdKey: Baggage.Key {
     typealias Value = Int
-    static var name: String? { "aws-request-id" }
+    static var nameOverride: String? { "aws-request-id" }
 }
 
 private enum AWSServiceKey: Baggage.Key {
     typealias Value = String
-    static var name: String? { "aws-service" }
+    static var nameOverride: String? { "aws-service" }
 }
 
 private enum AWSOperationKey: Baggage.Key {
     typealias Value = String
-    static var name: String? { "aws-operation" }
+    static var nameOverride: String? { "aws-operation" }
 }
 
 extension Baggage {
     var awsService: String? {
         get {
-            self[_key: AWSServiceKey.self]
+            self[AWSServiceKey.self]
         }
         set {
-            self[_key: AWSServiceKey.self] = newValue
+            self[AWSServiceKey.self] = newValue
         }
     }
 
     var awsOperation: String? {
         get {
-            self[_key: AWSOperationKey.self]
+            self[AWSOperationKey.self]
         }
         set {
-            self[_key: AWSOperationKey.self] = newValue
+            self[AWSOperationKey.self] = newValue
         }
     }
 
     var awsRequestId: Int? {
         get {
-            self[_key: RequestIdKey.self]
+            self[RequestIdKey.self]
         }
         set {
-            self[_key: RequestIdKey.self] = newValue
+            self[RequestIdKey.self] = newValue
         }
     }
 }

--- a/Sources/SotoCore/Baggage.swift
+++ b/Sources/SotoCore/Baggage.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2020 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Baggage
+
+private enum RequestIdKey: Baggage.Key {
+    typealias Value = Int
+    static var name: String? { "aws-request-id" }
+}
+
+private enum AWSServiceKey: Baggage.Key {
+    typealias Value = String
+    static var name: String? { "aws-service" }
+}
+
+private enum AWSOperationKey: Baggage.Key {
+    typealias Value = String
+    static var name: String? { "aws-operation" }
+}
+
+extension Baggage {
+    var awsService: String? {
+        get {
+            self[_key: AWSServiceKey.self]
+        }
+        set {
+            self[_key: AWSServiceKey.self] = newValue
+        }
+    }
+
+    var awsOperation: String? {
+        get {
+            self[_key: AWSOperationKey.self]
+        }
+        set {
+            self[_key: AWSOperationKey.self] = newValue
+        }
+    }
+
+    var awsRequestId: Int? {
+        get {
+            self[_key: RequestIdKey.self]
+        }
+        set {
+            self[_key: RequestIdKey.self] = newValue
+        }
+
+    }
+}

--- a/Sources/SotoCore/Credential/MetaDataCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/MetaDataCredentialProvider.swift
@@ -20,6 +20,7 @@ import struct Foundation.TimeInterval
 import struct Foundation.TimeZone
 import struct Foundation.URL
 
+import BaggageContext
 import Logging
 import NIO
 import NIOConcurrencyHelpers
@@ -119,7 +120,12 @@ struct ECSMetaDataClient: MetaDataClient {
 
     private func request(url: String, timeout: TimeInterval, on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<AWSHTTPResponse> {
         let request = AWSHTTPRequest(url: URL(string: url)!, method: .GET, headers: [:], body: .empty)
-        return httpClient.execute(request: request, timeout: TimeAmount.seconds(2), on: eventLoop, logger: logger)
+        return httpClient.execute(
+            request: request,
+            timeout: TimeAmount.seconds(2),
+            on: eventLoop,
+            context: DefaultContext.TODO(logger: logger, "Replace with context passed to credential provider when implemented")
+        )
     }
 }
 
@@ -258,6 +264,11 @@ struct InstanceMetaDataClient: MetaDataClient {
         logger: Logger
     ) -> EventLoopFuture<AWSHTTPResponse> {
         let request = AWSHTTPRequest(url: url, method: method, headers: headers, body: .empty)
-        return httpClient.execute(request: request, timeout: timeout, on: eventLoop, logger: logger)
+        return httpClient.execute(
+            request: request,
+            timeout: timeout,
+            on: eventLoop,
+            context: DefaultContext.TODO(logger: logger, "Replace with context passed to credential provider when implemented")
+        )
     }
 }

--- a/Sources/SotoCore/Exports.swift
+++ b/Sources/SotoCore/Exports.swift
@@ -15,10 +15,6 @@
 @_exported import protocol SotoSignerV4.Credential
 @_exported import struct SotoSignerV4.StaticCredential
 
-@_exported import protocol BaggageContext.Context
-
-@_exported import struct Logging.Logger
-
 @_exported import struct NIO.ByteBuffer
 @_exported import struct NIO.ByteBufferAllocator
 @_exported import protocol NIO.EventLoop

--- a/Sources/SotoCore/Exports.swift
+++ b/Sources/SotoCore/Exports.swift
@@ -15,6 +15,8 @@
 @_exported import protocol SotoSignerV4.Credential
 @_exported import struct SotoSignerV4.StaticCredential
 
+@_exported import protocol BaggageContext.Context
+
 @_exported import struct Logging.Logger
 
 @_exported import struct NIO.ByteBuffer

--- a/Sources/SotoCore/HTTP/AWSHTTPClient.swift
+++ b/Sources/SotoCore/HTTP/AWSHTTPClient.swift
@@ -44,10 +44,10 @@ public protocol AWSHTTPClient {
     typealias ResponseStream = (ByteBuffer, EventLoop) -> EventLoopFuture<Void>
 
     /// Execute HTTP request and return a future holding a HTTP Response
-    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<AWSHTTPResponse>
+    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: Context) -> EventLoopFuture<AWSHTTPResponse>
 
     /// Execute an HTTP request with a streamed response
-    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse>
+    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: Context, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse>
 
     /// This should be called before an HTTP Client can be de-initialised
     func shutdown(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void)
@@ -58,7 +58,7 @@ public protocol AWSHTTPClient {
 
 extension AWSHTTPClient {
     /// Execute an HTTP request with a streamed response
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: Context, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
         preconditionFailure("\(type(of: self)) does not support response streaming")
     }
 }

--- a/Sources/SotoCore/HTTP/AWSHTTPClient.swift
+++ b/Sources/SotoCore/HTTP/AWSHTTPClient.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BaggageContext
 import Foundation
 import Logging
 import NIO

--- a/Sources/SotoCore/HTTP/AWSHTTPClient.swift
+++ b/Sources/SotoCore/HTTP/AWSHTTPClient.swift
@@ -45,10 +45,10 @@ public protocol AWSHTTPClient {
     typealias ResponseStream = (ByteBuffer, EventLoop) -> EventLoopFuture<Void>
 
     /// Execute HTTP request and return a future holding a HTTP Response
-    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: Context) -> EventLoopFuture<AWSHTTPResponse>
+    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: BaggageContext) -> EventLoopFuture<AWSHTTPResponse>
 
     /// Execute an HTTP request with a streamed response
-    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: Context, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse>
+    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: BaggageContext, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse>
 
     /// This should be called before an HTTP Client can be de-initialised
     func shutdown(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void)
@@ -59,7 +59,7 @@ public protocol AWSHTTPClient {
 
 extension AWSHTTPClient {
     /// Execute an HTTP request with a streamed response
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: Context, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: BaggageContext, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
         preconditionFailure("\(type(of: self)) does not support response streaming")
     }
 }

--- a/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient
+import BaggageContext
 import Logging
 import NIO
 import NIOHTTP1

--- a/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
@@ -26,7 +26,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
     ///   - timeout: If execution is idle for longer than timeout then throw error
     ///   - eventLoop: eventLoop to run request on
     /// - Returns: EventLoopFuture that will be fulfilled with request response
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: Context) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: BaggageContext) -> EventLoopFuture<AWSHTTPResponse> {
         let requestBody: AsyncHTTPClient.HTTPClient.Body?
         var requestHeaders = request.headers
 
@@ -59,7 +59,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
         }
     }
 
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: Context, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: BaggageContext, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
         let requestBody: AsyncHTTPClient.HTTPClient.Body?
         if case .byteBuffer(let body) = request.body.payload {
             requestBody = .byteBuffer(body)

--- a/Sources/SotoTestUtils/TestUtils.swift
+++ b/Sources/SotoTestUtils/TestUtils.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BaggageContext
 import Foundation
 import Logging
 @testable import SotoCore
@@ -112,5 +113,9 @@ public struct TestEnvironment {
             }
         }
         return AWSClient.loggingDisabled
+    }()
+
+    public static var context: Context = {
+        DefaultContext.topLevel(logger: logger)
     }()
 }

--- a/Sources/SotoTestUtils/TestUtils.swift
+++ b/Sources/SotoTestUtils/TestUtils.swift
@@ -115,7 +115,7 @@ public struct TestEnvironment {
         return AWSClient.loggingDisabled
     }()
 
-    public static var context: Context = {
+    public static var context: BaggageContext = {
         DefaultContext.topLevel(logger: logger)
     }()
 }

--- a/Tests/SotoCoreTests/AWSClientTests.swift
+++ b/Tests/SotoCoreTests/AWSClientTests.swift
@@ -95,7 +95,7 @@ class AWSClientTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
         }
-        let response: EventLoopFuture<AWSTestServer.HTTPBinResponse> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+        let response: EventLoopFuture<AWSTestServer.HTTPBinResponse> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, context: TestEnvironment.context)
 
         XCTAssertNoThrow(try awsServer.httpBin())
         var httpBinResponse: AWSTestServer.HTTPBinResponse?
@@ -119,7 +119,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try awsServer.stop())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, context: TestEnvironment.context)
 
             try awsServer.processRaw { _ in
                 let response = AWSTestServer.Response(httpStatus: .ok, headers: [:], body: nil)
@@ -151,7 +151,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try awsServer.stop())
             }
             let input = Input(e: .second, i: [1, 2, 4, 8])
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, context: TestEnvironment.context)
 
             try awsServer.processRaw { request in
                 let receivedInput = try JSONDecoder().decode(Input.self, from: request.body)
@@ -180,7 +180,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try awsServer.stop())
             }
-            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, context: TestEnvironment.context)
 
             try awsServer.processRaw { _ in
                 let output = Output(s: "TestOutputString", i: 547)
@@ -217,7 +217,7 @@ class AWSClientTests: XCTestCase {
             return eventLoop.makeSucceededFuture(.byteBuffer(buffer))
         }
         let input = Input(payload: payload)
-        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, context: TestEnvironment.context)
 
         try server.processRaw { request in
             let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
@@ -290,7 +290,7 @@ class AWSClientTests: XCTestCase {
                 return eventLoop.makeSucceededFuture(.byteBuffer(buffer))
             }
             let input = Input(payload: payload)
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, context: TestEnvironment.context)
             try response.wait()
         } catch let error as HTTPClientError where error == .bodyLengthMismatch {
         } catch {
@@ -335,7 +335,7 @@ class AWSClientTests: XCTestCase {
             }
 
             let input = Input(payload: .fileHandle(fileHandle, size: bufferSize, fileIO: fileIO) { size in print(size) })
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, context: TestEnvironment.context)
 
             try awsServer.processRaw { request in
                 XCTAssertNil(request.headers["transfer-encoding"])
@@ -387,7 +387,7 @@ class AWSClientTests: XCTestCase {
                 }
             }
             let input = Input(payload: payload)
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, context: TestEnvironment.context)
 
             try awsServer.processRaw { request in
                 let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
@@ -416,7 +416,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, context: TestEnvironment.context)
 
             try awsServer.processRaw { _ in
                 let response = AWSTestServer.Response(httpStatus: .temporaryRedirect, headers: ["Location": awsServer.address], body: nil)
@@ -452,7 +452,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, context: TestEnvironment.context)
 
             var count = 0
             try awsServer.processRaw { _ in
@@ -496,7 +496,7 @@ class AWSClientTests: XCTestCase {
                 path: "/",
                 httpMethod: .POST,
                 serviceConfig: config,
-                logger: TestEnvironment.logger
+                context: TestEnvironment.context
             )
 
             var count = 0
@@ -552,7 +552,7 @@ class AWSClientTests: XCTestCase {
                 path: "/",
                 httpMethod: .POST,
                 serviceConfig: config,
-                logger: TestEnvironment.logger
+                context: TestEnvironment.context
             )
 
             try response.wait()
@@ -582,7 +582,7 @@ class AWSClientTests: XCTestCase {
                 path: "/",
                 httpMethod: .POST,
                 serviceConfig: config,
-                logger: TestEnvironment.logger
+                context: TestEnvironment.context
             )
 
             try awsServer.processRaw { _ in
@@ -618,8 +618,8 @@ class AWSClientTests: XCTestCase {
                 path: "/",
                 httpMethod: .POST,
                 serviceConfig: config,
-                on: eventLoop,
-                logger: TestEnvironment.logger
+                context: TestEnvironment.context,
+                on: eventLoop
             )
 
             try awsServer.processRaw { _ in
@@ -660,7 +660,7 @@ class AWSClientTests: XCTestCase {
                 httpMethod: .GET,
                 serviceConfig: config,
                 input: Input(),
-                logger: TestEnvironment.logger
+                context: TestEnvironment.context
             ) { (payload: ByteBuffer, eventLoop: EventLoop) in
                 let payloadSize = payload.readableBytes
                 let slice = Data(data[count..<(count + payloadSize)])
@@ -713,7 +713,7 @@ class AWSClientTests: XCTestCase {
             httpMethod: .GET,
             serviceConfig: config,
             input: Input(),
-            logger: TestEnvironment.logger
+            context: TestEnvironment.context
         ) { (_: ByteBuffer, eventLoop: EventLoop) in
             lock.withLock { count += 1 }
             return eventLoop.scheduleTask(in: .milliseconds(200)) {
@@ -749,7 +749,7 @@ class AWSClientTests: XCTestCase {
             XCTAssertNoThrow(try awsServer.stop())
         }
 
-        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, context: TestEnvironment.context)
 
         XCTAssertNoThrow(try awsServer.processRaw { request in
             XCTAssertEqual(request.uri, "/test")

--- a/Tests/SotoCoreTests/PaginateTests.swift
+++ b/Tests/SotoCoreTests/PaginateTests.swift
@@ -67,7 +67,7 @@ class PaginateTests: XCTestCase {
         let outputToken: Int?
     }
 
-    func counter(_ input: CounterInput, context: Context, on eventLoop: EventLoop?) -> EventLoopFuture<CounterOutput> {
+    func counter(_ input: CounterInput, context: BaggageContext, on eventLoop: EventLoop?) -> EventLoopFuture<CounterOutput> {
         return self.client.execute(
             operation: "TestOperation",
             path: "/",
@@ -146,7 +146,7 @@ class PaginateTests: XCTestCase {
         let moreResults: Bool?
     }
 
-    func stringList(_ input: StringListInput, context: Context, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StringListOutput> {
+    func stringList(_ input: StringListInput, context: BaggageContext, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StringListOutput> {
         return self.client.execute(
             operation: "TestOperation",
             path: "/",

--- a/Tests/SotoCoreTests/PaginateTests.swift
+++ b/Tests/SotoCoreTests/PaginateTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient
+import BaggageContext
 import NIO
 @testable import SotoCore
 import SotoTestUtils
@@ -66,15 +67,15 @@ class PaginateTests: XCTestCase {
         let outputToken: Int?
     }
 
-    func counter(_ input: CounterInput, on eventLoop: EventLoop?, logger: Logger) -> EventLoopFuture<CounterOutput> {
+    func counter(_ input: CounterInput, context: Context, on eventLoop: EventLoop?) -> EventLoopFuture<CounterOutput> {
         return self.client.execute(
             operation: "TestOperation",
             path: "/",
             httpMethod: .POST,
             serviceConfig: self.config,
             input: input,
-            on: eventLoop,
-            logger: logger
+            context: context,
+            on: eventLoop
         )
     }
 
@@ -83,7 +84,7 @@ class PaginateTests: XCTestCase {
             input: input,
             command: self.counter,
             tokenKey: \CounterOutput.outputToken,
-            logger: TestEnvironment.logger,
+            context: TestEnvironment.context,
             onPage: onPage
         )
     }
@@ -145,15 +146,15 @@ class PaginateTests: XCTestCase {
         let moreResults: Bool?
     }
 
-    func stringList(_ input: StringListInput, on eventLoop: EventLoop? = nil, logger: Logger) -> EventLoopFuture<StringListOutput> {
+    func stringList(_ input: StringListInput, context: Context, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StringListOutput> {
         return self.client.execute(
             operation: "TestOperation",
             path: "/",
             httpMethod: .POST,
             serviceConfig: self.config,
             input: input,
-            on: eventLoop,
-            logger: logger
+            context: context,
+            on: eventLoop
         )
     }
 
@@ -163,8 +164,8 @@ class PaginateTests: XCTestCase {
             command: self.stringList,
             tokenKey: \StringListOutput.outputToken,
             moreResultsKey: \StringListOutput.moreResults,
+            context: TestEnvironment.context,
             on: eventLoop,
-            logger: TestEnvironment.logger,
             onPage: onPage
         )
     }

--- a/Tests/SotoCoreTests/PayloadTests.swift
+++ b/Tests/SotoCoreTests/PayloadTests.swift
@@ -40,7 +40,7 @@ class PayloadTests: XCTestCase {
                 httpMethod: .POST,
                 serviceConfig: config,
                 input: input,
-                logger: TestEnvironment.logger
+                context: TestEnvironment.context
             )
 
             try awsServer.processRaw { request in
@@ -87,7 +87,7 @@ class PayloadTests: XCTestCase {
                 path: "/",
                 httpMethod: .POST,
                 serviceConfig: config,
-                logger: TestEnvironment.logger
+                context: TestEnvironment.context
             )
 
             try awsServer.processRaw { _ in

--- a/Tests/SotoCoreTests/PerformanceTests.swift
+++ b/Tests/SotoCoreTests/PerformanceTests.swift
@@ -239,7 +239,7 @@ class PerformanceTests: XCTestCase {
             configuration: config
         ).applyMiddlewares(config.middlewares + client.middlewares, config: config)
 
-        let signer = try! client.createSigner(config: config, context: AWSClient.emptyContext).wait()
+        let signer = try! client.createSigner(config: config, context: AWSClient.defaultBaggageContext()).wait()
         let byteBufferAllocator = ByteBufferAllocator()
         measure {
             for _ in 0..<1000 {

--- a/Tests/SotoCoreTests/PerformanceTests.swift
+++ b/Tests/SotoCoreTests/PerformanceTests.swift
@@ -239,7 +239,7 @@ class PerformanceTests: XCTestCase {
             configuration: config
         ).applyMiddlewares(config.middlewares + client.middlewares, config: config)
 
-        let signer = try! client.createSigner(serviceConfig: config, logger: AWSClient.loggingDisabled).wait()
+        let signer = try! client.createSigner(config: config, context: AWSClient.emptyContext).wait()
         let byteBufferAllocator = ByteBufferAllocator()
         measure {
             for _ in 0..<1000 {


### PR DESCRIPTION
Changes required to the public API of Soto for integrating with the swift tracing code. It is not intended that I add instrumentation code here. All we are doing is passing in the `Context`

The PR has a fairly limited scope in that it only covers the interface functions of AWSClient and passes the `Context` down to the HTTP client. Although we can't actually pass it to `AsyncHTTPClient.HTTPClient` yet. 

I have another branch which also passes the `Context` to the `CredentialProviders` but didn't include it here as the number of files that were touched by that change would make this difficult to review.