### PR TITLE
signURL parameter expires no longer has a default

### DIFF
--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -473,7 +473,7 @@ extension AWSClient {
         url: URL,
         httpMethod: HTTPMethod,
         headers: HTTPHeaders = HTTPHeaders(),
-        expires: Int = 86400,
+        expires: TimeAmount,
         serviceConfig: AWSServiceConfig,
         logger: Logger = AWSClient.loggingDisabled
     ) -> EventLoopFuture<URL> {

--- a/Sources/SotoCore/AWSService.swift
+++ b/Sources/SotoCore/AWSService.swift
@@ -12,7 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
+import struct Foundation.URL
+import NIO
 
 public protocol AWSService {
     /// client used to communicate with AWS
@@ -42,7 +43,7 @@ extension AWSService {
         url: URL,
         httpMethod: HTTPMethod,
         headers: HTTPHeaders = HTTPHeaders(),
-        expires: Int = 86400,
+        expires: TimeAmount,
         logger: Logger = AWSClient.loggingDisabled
     ) -> EventLoopFuture<URL> {
         return self.client.signURL(url: url, httpMethod: httpMethod, headers: headers, expires: expires, serviceConfig: self.config, logger: logger)

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -81,7 +81,7 @@ public struct AWSSigner {
     }
 
     /// Generate a signed URL, for a HTTP request
-    public func signURL(url: URL, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: BodyData? = nil, date: Date = Date(), expires: Int = 86400) -> URL {
+    public func signURL(url: URL, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: BodyData? = nil, expires: TimeAmount, date: Date = Date()) -> URL {
         var headers = headers
         headers.replaceOrAdd(name: "host", value: url.host ?? "")
         // Create signing data
@@ -94,7 +94,7 @@ public struct AWSSigner {
         query += "X-Amz-Algorithm=AWS4-HMAC-SHA256"
         query += "&X-Amz-Credential=\(credentials.accessKeyId)/\(signingData.date)/\(region)/\(name)/aws4_request"
         query += "&X-Amz-Date=\(signingData.datetime)"
-        query += "&X-Amz-Expires=\(expires)"
+        query += "&X-Amz-Expires=\(expires.nanoseconds / 1_000_000_000)"
         query += "&X-Amz-SignedHeaders=\(signingData.signedHeaders)"
         if let sessionToken = credentials.sessionToken {
             query += "&X-Amz-Security-Token=\(sessionToken.uriEncode())"

--- a/Tests/SotoSignerV4Tests/AWSSignerTests.swift
+++ b/Tests/SotoSignerV4Tests/AWSSignerTests.swift
@@ -56,19 +56,19 @@ final class AWSSignerTests: XCTestCase {
 
     func testSignS3GetURL() {
         let signer = AWSSigner(credentials: credentials, name: "s3", region: "us-east-1")
-        let url = signer.signURL(url: URL(string: "https://s3.us-east-1.amazonaws.com/")!, method: .GET, date: Date(timeIntervalSinceReferenceDate: 100_000))
+        let url = signer.signURL(url: URL(string: "https://s3.us-east-1.amazonaws.com/")!, method: .GET, expires: .hours(24), date: Date(timeIntervalSinceReferenceDate: 100_000))
         XCTAssertEqual(url.absoluteString, "https://s3.us-east-1.amazonaws.com/?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=MYACCESSKEY%2F20010102%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20010102T034640Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=27957103c8bfdff3560372b1d85976ed29c944f34295eca2d4fdac7fc02c375a")
     }
 
     func testSignS3GetWithQueryURL() {
         let signer = AWSSigner(credentials: credentials, name: "s3", region: "us-east-1")
-        let url = signer.signURL(url: URL(string: "https://s3.us-east-1.amazonaws.com/testFile?versionId=1")!, method: .GET, date: Date(timeIntervalSinceReferenceDate: 100_000))
+        let url = signer.signURL(url: URL(string: "https://s3.us-east-1.amazonaws.com/testFile?versionId=1")!, method: .GET, expires: .hours(24), date: Date(timeIntervalSinceReferenceDate: 100_000))
         XCTAssertEqual(url.absoluteString, "https://s3.us-east-1.amazonaws.com/testFile?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=MYACCESSKEY%2F20010102%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20010102T034640Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&versionId=1&X-Amz-Signature=22678dbcdbbc468c306757c8abd021e093e588e4eba7d0d0da9b92717bbcc1b0")
     }
 
     func testSignS3PutURL() {
         let signer = AWSSigner(credentials: credentialsWithSessionKey, name: "s3", region: "eu-west-1")
-        let url = signer.signURL(url: URL(string: "https://test-bucket.s3.amazonaws.com/test-put.txt")!, method: .PUT, body: .string("Testing signed URLs"), date: Date(timeIntervalSinceReferenceDate: 100_000))
+        let url = signer.signURL(url: URL(string: "https://test-bucket.s3.amazonaws.com/test-put.txt")!, method: .PUT, body: .string("Testing signed URLs"), expires: .hours(24), date: Date(timeIntervalSinceReferenceDate: 100_000))
         XCTAssertEqual(url.absoluteString, "https://test-bucket.s3.amazonaws.com/test-put.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=MYACCESSKEY%2F20010102%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20010102T034640Z&X-Amz-Expires=86400&X-Amz-Security-Token=MYSESSIONTOKEN&X-Amz-SignedHeaders=host&X-Amz-Signature=969dfbc450089f34f5b430611b18def1701c72c9e7e1608142051a898094227e")
     }
 
@@ -78,6 +78,7 @@ final class AWSSignerTests: XCTestCase {
             url: URL(string: "https://test-bucket.s3.amazonaws.com/test-put.txt")!,
             method: .PUT,
             headers: ["x-amz-acl": "public-read"],
+            expires: .hours(24),
             date: Date(timeIntervalSinceReferenceDate: 100_000)
         )
         XCTAssertEqual(url.absoluteString, "https://test-bucket.s3.amazonaws.com/test-put.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=MYACCESSKEY%2F20010102%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20010102T034640Z&X-Amz-Expires=86400&X-Amz-Security-Token=MYSESSIONTOKEN&X-Amz-SignedHeaders=host%3Bx-amz-acl&X-Amz-Signature=a849c034af312e8424b3b0dd425e3e21ce7a61641f4b6a84c203b115447309c8")
@@ -106,7 +107,7 @@ final class AWSSignerTests: XCTestCase {
 
         measure {
             for _ in 0..<1000 {
-                _ = signer.signURL(url: URL(string: "https://test-bucket.s3.amazonaws.com/test-put.txt")!, method: .GET)
+                _ = signer.signURL(url: URL(string: "https://test-bucket.s3.amazonaws.com/test-put.txt")!, method: .GET, expires: .hours(24))
             }
         }
     }


### PR DESCRIPTION
Also changed this to a `TimeAmount` instead of an `Int`. Makes for easier reading

```
let url = signer.signURL(
    url: URL(string: "https://test-bucket.s3.amazonaws.com/test-put.txt")!, 
    method: .GET, 
    expires: .minutes(30)
)
```