### PR TITLE
Coding to CustomCoding

### DIFF
--- a/Sources/SotoCore/Encoder/CodableProperties/CodableProperties.swift
+++ b/Sources/SotoCore/Encoder/CodableProperties/CodableProperties.swift
@@ -58,7 +58,7 @@ extension CustomCoding: Encodable where Coder: CustomEncoder {
 }
 
 /// Property wrapper that applies a custom encoder and decoder to its wrapped optional value
-@propertyWrapper public struct OptionalCoding<Coder: CustomCoder> {
+@propertyWrapper public struct OptionalCustomCoding<Coder: CustomCoder> {
     var value: Coder.CodableValue?
 
     public init(wrappedValue value: Coder.CodableValue?) {
@@ -72,22 +72,22 @@ extension CustomCoding: Encodable where Coder: CustomEncoder {
 }
 
 /// add decode functionality if propertyWrapper conforms to `Decodable` and Coder conforms to `CustomDecoder`
-extension OptionalCoding: Decodable where Coder: CustomDecoder {
+extension OptionalCustomCoding: Decodable where Coder: CustomDecoder {
     public init(from decoder: Decoder) throws {
         self.value = try Coder.decode(from: decoder)
     }
 }
 
 /// add encoder functionality if propertyWrapper conforms to `Encodable` and Coder conforms to `CustomEncoder`
-extension OptionalCoding: Encodable where Coder: CustomEncoder {
+extension OptionalCustomCoding: Encodable where Coder: CustomEncoder {
     public func encode(to encoder: Encoder) throws {
         guard let value = self.value else { return }
         try Coder.encode(value: value, to: encoder)
     }
 }
 
-/// Protocol for a PropertyWrapper to properly handle Coding when the wrappedValue is Optional
-public protocol OptionalCodingWrapper {
+/// Protocol for a PropertyWrapper to properly handle CustomCoding when the wrappedValue is Optional
+public protocol OptionalCustomCodingWrapper {
     associatedtype WrappedType
     var wrappedValue: WrappedType? { get }
     init(wrappedValue: WrappedType?)
@@ -96,7 +96,7 @@ public protocol OptionalCodingWrapper {
 /// extending `KeyedDecodingContainer` so it will only decode an optional value if it is present
 extension KeyedDecodingContainer {
     // This is used to override the default decoding behavior for OptionalCodingWrapper to allow a value to avoid a missing key Error
-    public func decode<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> T where T: Decodable, T: OptionalCodingWrapper {
+    public func decode<T>(_ type: T.Type, forKey key: KeyedDecodingContainer<K>.Key) throws -> T where T: Decodable, T: OptionalCustomCodingWrapper {
         return try decodeIfPresent(T.self, forKey: key) ?? T(wrappedValue: nil)
     }
 }
@@ -104,14 +104,14 @@ extension KeyedDecodingContainer {
 /// extending `KeyedEncodingContainer` so it will only encode a wrapped value it is non nil
 extension KeyedEncodingContainer {
     // Used to make make sure OptionalCodingWrappers encode no value when it's wrappedValue is nil.
-    public mutating func encode<T>(_ value: T, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable, T: OptionalCodingWrapper {
+    public mutating func encode<T>(_ value: T, forKey key: KeyedEncodingContainer<K>.Key) throws where T: Encodable, T: OptionalCustomCodingWrapper {
         guard value.wrappedValue != nil else { return }
         try encodeIfPresent(value, forKey: key)
     }
 }
 
 /// extend OptionalCoding so it conforms to OptionalCodingWrapper
-extension OptionalCoding: OptionalCodingWrapper {}
+extension OptionalCustomCoding: OptionalCustomCodingWrapper {}
 
 /// CodingKey used by Encoder property wrappers
 internal struct EncodingWrapperKey: CodingKey {

--- a/Sources/SotoCore/Encoder/CodableProperties/CodableProperties.swift
+++ b/Sources/SotoCore/Encoder/CodableProperties/CodableProperties.swift
@@ -30,7 +30,7 @@ public protocol CustomDecoder: CustomCoder {
 }
 
 /// Property wrapper that applies a custom encoder and decoder to its wrapped value
-@propertyWrapper public struct Coding<Coder: CustomCoder> {
+@propertyWrapper public struct CustomCoding<Coder: CustomCoder> {
     var value: Coder.CodableValue
 
     public init(wrappedValue value: Coder.CodableValue) {
@@ -44,14 +44,14 @@ public protocol CustomDecoder: CustomCoder {
 }
 
 /// add decode functionality if propertyWrapper conforms to `Decodable` and Coder conforms to `CustomDecoder`
-extension Coding: Decodable where Coder: CustomDecoder {
+extension CustomCoding: Decodable where Coder: CustomDecoder {
     public init(from decoder: Decoder) throws {
         self.value = try Coder.decode(from: decoder)
     }
 }
 
 /// add encoder functionality if propertyWrapper conforms to `Encodable` and Coder conforms to `CustomEncoder`
-extension Coding: Encodable where Coder: CustomEncoder {
+extension CustomCoding: Encodable where Coder: CustomEncoder {
     public func encode(to encoder: Encoder) throws {
         try Coder.encode(value: self.value, to: encoder)
     }

--- a/Sources/SotoCore/Encoder/CodableProperties/CollectionCoders.swift
+++ b/Sources/SotoCore/Encoder/CodableProperties/CollectionCoders.swift
@@ -119,16 +119,16 @@ extension DictionaryCoder: CustomEncoder where Key: Encodable, Value: Encodable 
 }
 
 /// The most common array encoding property is an element name "member"
-public struct DefaultArrayCoderProperties: ArrayCoderProperties {
+public struct StandardArrayCoderProperties: ArrayCoderProperties {
     public static let member = "member"
 }
 
 /// The most common dictionary encoding properties are element name "entry", key name "key", value name "value"
-public struct DefaultDictionaryCoderProperties: DictionaryCoderProperties {
+public struct StandardDictionaryCoderProperties: DictionaryCoderProperties {
     public static let entry: String? = "entry"
     public static let key = "key"
     public static let value = "value"
 }
 
-public typealias DefaultArrayCoder<Element> = ArrayCoder<DefaultArrayCoderProperties, Element>
-public typealias DefaultDictionaryCoder<Key: Codable & Hashable, Value> = DictionaryCoder<DefaultDictionaryCoderProperties, Key, Value>
+public typealias StandardArrayCoder<Element> = ArrayCoder<StandardArrayCoderProperties, Element>
+public typealias StandardDictionaryCoder<Key: Codable & Hashable, Value> = DictionaryCoder<StandardDictionaryCoderProperties, Key, Value>

--- a/Tests/SotoCoreTests/QueryEncoderTests.swift
+++ b/Tests/SotoCoreTests/QueryEncoderTests.swift
@@ -125,7 +125,7 @@ class QueryEncoderTests: XCTestCase {
 
     func testDictionaryEncode() {
         struct Test: AWSEncodableShape {
-            @CustomCoding<DefaultDictionaryCoder> var a: [String: Int]
+            @CustomCoding<StandardDictionaryCoder> var a: [String: Int]
 
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
@@ -149,7 +149,7 @@ class QueryEncoderTests: XCTestCase {
                 case second
             }
 
-            @CustomCoding<DefaultDictionaryCoder> var a: [TestEnum: Test2]
+            @CustomCoding<StandardDictionaryCoder> var a: [TestEnum: Test2]
 
             private enum CodingKeys: String, CodingKey {
                 case a = "A"

--- a/Tests/SotoCoreTests/QueryEncoderTests.swift
+++ b/Tests/SotoCoreTests/QueryEncoderTests.swift
@@ -113,7 +113,7 @@ class QueryEncoderTests: XCTestCase {
             }
         }
         struct Test: AWSEncodableShape {
-            @Coding<ArrayCoder<ArrayM, Test2>> var a: [Test2]
+            @CustomCoding<ArrayCoder<ArrayM, Test2>> var a: [Test2]
 
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
@@ -125,7 +125,7 @@ class QueryEncoderTests: XCTestCase {
 
     func testDictionaryEncode() {
         struct Test: AWSEncodableShape {
-            @Coding<DefaultDictionaryCoder> var a: [String: Int]
+            @CustomCoding<DefaultDictionaryCoder> var a: [String: Int]
 
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
@@ -149,7 +149,7 @@ class QueryEncoderTests: XCTestCase {
                 case second
             }
 
-            @Coding<DefaultDictionaryCoder> var a: [TestEnum: Test2]
+            @CustomCoding<DefaultDictionaryCoder> var a: [TestEnum: Test2]
 
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
@@ -162,7 +162,7 @@ class QueryEncoderTests: XCTestCase {
     func testArrayEncodingEncode() {
         struct ArrayItem: ArrayCoderProperties { static let member = "item" }
         struct Test: AWSEncodableShape {
-            @Coding<ArrayCoder<ArrayItem, Int>> var a: [Int]
+            @CustomCoding<ArrayCoder<ArrayItem, Int>> var a: [Int]
         }
         let test = Test(a: [9, 8, 7, 6])
         testQuery(test, query: "a.item.1=9&a.item.2=8&a.item.3=7&a.item.4=6")
@@ -171,7 +171,7 @@ class QueryEncoderTests: XCTestCase {
     func testDictionaryEncodingEncode() {
         struct DictionaryItemKV: DictionaryCoderProperties { static let entry: String? = "item"; static let key = "k"; static let value = "v" }
         struct Test: AWSEncodableShape {
-            @Coding<DictionaryCoder<DictionaryItemKV, String, Int>> var a: [String: Int]
+            @CustomCoding<DictionaryCoder<DictionaryItemKV, String, Int>> var a: [String: Int]
 
             private enum CodingKeys: String, CodingKey {
                 case a = "A"
@@ -186,7 +186,7 @@ class QueryEncoderTests: XCTestCase {
             static let entry: String? = nil; static let key = "name"; static let value = "entry"
         }
         struct Test: AWSEncodableShape {
-            @Coding<DictionaryCoder<DictionaryNameEntry, String, Int>> var a: [String: Int]
+            @CustomCoding<DictionaryCoder<DictionaryNameEntry, String, Int>> var a: [String: Int]
 
             private enum CodingKeys: String, CodingKey {
                 case a = "A"

--- a/Tests/SotoCoreTests/TimeStampTests.swift
+++ b/Tests/SotoCoreTests/TimeStampTests.swift
@@ -42,7 +42,7 @@ class TimeStampTests: XCTestCase {
     func testDecodeISOFromXML() {
         do {
             struct A: Codable {
-                @Coding<ISO8601TimeStampCoder> var date: TimeStamp
+                @CustomCoding<ISO8601TimeStampCoder> var date: TimeStamp
             }
             let xml = "<A><date>2017-01-01T00:01:00.000Z</date></A>"
             let xmlElement = try XML.Element(xmlString: xml)
@@ -56,7 +56,7 @@ class TimeStampTests: XCTestCase {
     func testDecodeISONoMillisecondFromXML() {
         do {
             struct A: Codable {
-                @Coding<ISO8601TimeStampCoder> var date: TimeStamp
+                @CustomCoding<ISO8601TimeStampCoder> var date: TimeStamp
             }
             let xml = "<A><date>2017-01-01T00:01:00Z</date></A>"
             let xmlElement = try XML.Element(xmlString: xml)
@@ -98,7 +98,7 @@ class TimeStampTests: XCTestCase {
     func testEncodeISO8601ToXML() {
         do {
             struct A: Codable {
-                @Coding<ISO8601TimeStampCoder> var date: TimeStamp
+                @CustomCoding<ISO8601TimeStampCoder> var date: TimeStamp
             }
             let a = A(date: TimeStamp("2019-05-01T00:00:00.001Z")!)
             let xml = try XMLEncoder().encode(a)
@@ -110,7 +110,7 @@ class TimeStampTests: XCTestCase {
 
     func testEncodeHTTPHeaderToJSON() {
         struct A: AWSEncodableShape {
-            @Coding<HTTPHeaderTimeStampCoder> var date: TimeStamp
+            @CustomCoding<HTTPHeaderTimeStampCoder> var date: TimeStamp
         }
         let a = A(date: TimeStamp("2019-05-01T00:00:00.001Z")!)
         let config = createServiceConfig()
@@ -123,7 +123,7 @@ class TimeStampTests: XCTestCase {
     func testEncodeUnixEpochToJSON() {
         do {
             struct A: Codable {
-                @Coding<UnixEpochTimeStampCoder> var date: TimeStamp
+                @CustomCoding<UnixEpochTimeStampCoder> var date: TimeStamp
             }
             let a = A(date: TimeStamp(23_983_978_378))
             let data = try JSONEncoder().encode(a)

--- a/Tests/SotoXMLTests/XMLCoderTests.swift
+++ b/Tests/SotoXMLTests/XMLCoderTests.swift
@@ -159,7 +159,7 @@ class XMLCoderTests: XCTestCase {
     func testArrayUserProperty() {
         struct ArrayMember2: ArrayCoderProperties { static let member = "member2" }
         struct Test: Codable {
-            @Coding<ArrayCoder<ArrayMember2, String>> var a: [String]
+            @CustomCoding<ArrayCoder<ArrayMember2, String>> var a: [String]
         }
         let test = Test(a: ["one", "two", "three"])
         do {
@@ -347,8 +347,8 @@ class XMLCoderTests: XCTestCase {
 
     func testDecodeExpandedContainers() {
         struct Shape: AWSDecodableShape {
-            @Coding<DefaultArrayCoder> var array: [Int]
-            @Coding<DefaultDictionaryCoder> var dictionary: [String: Int]
+            @CustomCoding<DefaultArrayCoder> var array: [Int]
+            @CustomCoding<DefaultDictionaryCoder> var dictionary: [String: Int]
         }
         let xmldata = "<Shape><array><member>3</member><member>2</member><member>1</member></array><dictionary><entry><key>one</key><value>1</value></entry><entry><key>two</key><value>2</value></entry><entry><key>three</key><value>3</value></entry></dictionary></Shape>"
         if let shape = testDecode(type: Shape.self, xml: xmldata) {
@@ -361,7 +361,7 @@ class XMLCoderTests: XCTestCase {
 
     func testArrayEncodingDecodeEncode() {
         struct Shape: AWSDecodableShape & AWSEncodableShape {
-            @Coding<DefaultArrayCoder> var array: [Int]
+            @CustomCoding<DefaultArrayCoder> var array: [Int]
         }
         let xmldata = "<Shape><array><member>3</member><member>2</member><member>1</member></array></Shape>"
         self.testDecodeEncode(type: Shape.self, xml: xmldata)
@@ -372,7 +372,7 @@ class XMLCoderTests: XCTestCase {
             let value: String
         }
         struct Shape: AWSDecodableShape & AWSEncodableShape {
-            @Coding<DefaultArrayCoder> var array: [Shape2]
+            @CustomCoding<DefaultArrayCoder> var array: [Shape2]
         }
         let xmldata = "<Shape><array><member><value>test</value></member><member><value>test2</value></member><member><value>test3</value></member></array></Shape>"
         self.testDecodeEncode(type: Shape.self, xml: xmldata)
@@ -381,7 +381,7 @@ class XMLCoderTests: XCTestCase {
     func testDictionaryEncodingDecodeEncode() {
         struct DictionaryItemKeyValue: DictionaryCoderProperties { static let entry: String? = "item"; static let key = "key"; static let value = "value" }
         struct Shape: AWSDecodableShape & AWSEncodableShape {
-            @Coding<DictionaryCoder<DictionaryItemKeyValue, String, Int>> var d: [String: Int]
+            @CustomCoding<DictionaryCoder<DictionaryItemKeyValue, String, Int>> var d: [String: Int]
         }
         let xmldata = "<Shape><d><item><key>member</key><value>4</value></item></d></Shape>"
         self.testDecodeEncode(type: Shape.self, xml: xmldata)
@@ -393,7 +393,7 @@ class XMLCoderTests: XCTestCase {
             let float: Float
         }
         struct Shape: AWSDecodableShape & AWSEncodableShape {
-            @Coding<DictionaryCoder<DictionaryItemKeyValue, String, Shape2>> var d: [String: Shape2]
+            @CustomCoding<DictionaryCoder<DictionaryItemKeyValue, String, Shape2>> var d: [String: Shape2]
         }
         let xmldata = "<Shape><d><item><key>member</key><value><float>1.5</float></value></item></d></Shape>"
         self.testDecodeEncode(type: Shape.self, xml: xmldata)
@@ -402,7 +402,7 @@ class XMLCoderTests: XCTestCase {
     func testFlatDictionaryEncodingDecodeEncode() {
         struct DictionaryKeyValue: DictionaryCoderProperties { static let entry: String? = nil; static let key = "key"; static let value = "value" }
         struct Shape: AWSDecodableShape & AWSEncodableShape {
-            @Coding<DictionaryCoder<DictionaryKeyValue, String, Int>> var d: [String: Int]
+            @CustomCoding<DictionaryCoder<DictionaryKeyValue, String, Int>> var d: [String: Int]
         }
         let xmldata = "<Shape><d><key>member</key><value>4</value></d></Shape>"
         self.testDecodeEncode(type: Shape.self, xml: xmldata)
@@ -415,7 +415,7 @@ class XMLCoderTests: XCTestCase {
             case member2
         }
         struct Shape: AWSDecodableShape & AWSEncodableShape {
-            @Coding<DictionaryCoder<DictionaryItemKeyValue, KeyEnum, Int>> var d: [KeyEnum: Int]
+            @CustomCoding<DictionaryCoder<DictionaryItemKeyValue, KeyEnum, Int>> var d: [KeyEnum: Int]
         }
         let xmldata = "<Shape><d><item><key>member</key><value>4</value></item></d></Shape>"
         self.testDecodeEncode(type: Shape.self, xml: xmldata)
@@ -431,7 +431,7 @@ class XMLCoderTests: XCTestCase {
             let a: String
         }
         struct Shape: AWSDecodableShape & AWSEncodableShape {
-            @Coding<DictionaryCoder<DictionaryItemKV, KeyEnum, Shape2>> var d: [KeyEnum: Shape2]
+            @CustomCoding<DictionaryCoder<DictionaryItemKV, KeyEnum, Shape2>> var d: [KeyEnum: Shape2]
         }
         let xmldata = "<Shape><d><item><k>member</k><v><a>thisisastring</a></v></item></d></Shape>"
         self.testDecodeEncode(type: Shape.self, xml: xmldata)
@@ -447,7 +447,7 @@ class XMLCoderTests: XCTestCase {
             let a: String
         }
         struct Shape: AWSDecodableShape & AWSEncodableShape {
-            @Coding<DictionaryCoder<DictionaryKeyValue, KeyEnum, Shape2>> var d: [KeyEnum: Shape2]
+            @CustomCoding<DictionaryCoder<DictionaryKeyValue, KeyEnum, Shape2>> var d: [KeyEnum: Shape2]
         }
         let xmldata = "<Shape><d><key>member</key><value><a>hello</a></value></d></Shape>"
         self.testDecodeEncode(type: Shape.self, xml: xmldata)

--- a/Tests/SotoXMLTests/XMLCoderTests.swift
+++ b/Tests/SotoXMLTests/XMLCoderTests.swift
@@ -174,7 +174,7 @@ class XMLCoderTests: XCTestCase {
 
     func testOptionalDictionary() {
         struct Test: Codable {
-            @OptionalCoding<DefaultDictionaryCoder> var a: [String: Int]?
+            @OptionalCustomCoding<DefaultDictionaryCoder> var a: [String: Int]?
         }
         let xml = "<Test><a><entry><key>one</key><value>1</value></entry></a></Test>"
         self.testDecodeEncode(type: Test.self, xml: xml)

--- a/Tests/SotoXMLTests/XMLCoderTests.swift
+++ b/Tests/SotoXMLTests/XMLCoderTests.swift
@@ -174,7 +174,7 @@ class XMLCoderTests: XCTestCase {
 
     func testOptionalDictionary() {
         struct Test: Codable {
-            @OptionalCustomCoding<DefaultDictionaryCoder> var a: [String: Int]?
+            @OptionalCustomCoding<StandardDictionaryCoder> var a: [String: Int]?
         }
         let xml = "<Test><a><entry><key>one</key><value>1</value></entry></a></Test>"
         self.testDecodeEncode(type: Test.self, xml: xml)
@@ -347,8 +347,8 @@ class XMLCoderTests: XCTestCase {
 
     func testDecodeExpandedContainers() {
         struct Shape: AWSDecodableShape {
-            @CustomCoding<DefaultArrayCoder> var array: [Int]
-            @CustomCoding<DefaultDictionaryCoder> var dictionary: [String: Int]
+            @CustomCoding<StandardArrayCoder> var array: [Int]
+            @CustomCoding<StandardDictionaryCoder> var dictionary: [String: Int]
         }
         let xmldata = "<Shape><array><member>3</member><member>2</member><member>1</member></array><dictionary><entry><key>one</key><value>1</value></entry><entry><key>two</key><value>2</value></entry><entry><key>three</key><value>3</value></entry></dictionary></Shape>"
         if let shape = testDecode(type: Shape.self, xml: xmldata) {
@@ -361,7 +361,7 @@ class XMLCoderTests: XCTestCase {
 
     func testArrayEncodingDecodeEncode() {
         struct Shape: AWSDecodableShape & AWSEncodableShape {
-            @CustomCoding<DefaultArrayCoder> var array: [Int]
+            @CustomCoding<StandardArrayCoder> var array: [Int]
         }
         let xmldata = "<Shape><array><member>3</member><member>2</member><member>1</member></array></Shape>"
         self.testDecodeEncode(type: Shape.self, xml: xmldata)
@@ -372,7 +372,7 @@ class XMLCoderTests: XCTestCase {
             let value: String
         }
         struct Shape: AWSDecodableShape & AWSEncodableShape {
-            @CustomCoding<DefaultArrayCoder> var array: [Shape2]
+            @CustomCoding<StandardArrayCoder> var array: [Shape2]
         }
         let xmldata = "<Shape><array><member><value>test</value></member><member><value>test2</value></member><member><value>test3</value></member></array></Shape>"
         self.testDecodeEncode(type: Shape.self, xml: xmldata)


### PR DESCRIPTION
Rename `Coding` property wrapper to `CustomCoding`. Coding is too generic a name for a public symbol.