### PR TITLE
Create new AWSService with updated serviceConfig values

### DIFF
--- a/Sources/SotoCore/AWSService.swift
+++ b/Sources/SotoCore/AWSService.swift
@@ -51,7 +51,14 @@ extension AWSService {
         return self.client.signURL(url: url, httpMethod: httpMethod, headers: headers, expires: expires, serviceConfig: self.config, logger: logger)
     }
 
-    func with(
+    /// Return new version of Service with edited parameters
+    /// - Parameters:
+    ///   - middlewares: Additional middleware to add
+    ///   - timeout: Time out value for HTTP requests
+    ///   - byteBufferAllocator: byte buffer allocator used throughout AWSClient
+    ///   - options: options used by client when processing requests
+    /// - Returns: New version of the service
+    public func with(
         middlewares: [AWSServiceMiddleware] = [],
         timeout: TimeAmount? = nil,
         byteBufferAllocator: ByteBufferAllocator? = nil,

--- a/Sources/SotoCore/AWSService.swift
+++ b/Sources/SotoCore/AWSService.swift
@@ -20,6 +20,8 @@ public protocol AWSService {
     var client: AWSClient { get }
     /// service context details
     var config: AWSServiceConfig { get }
+    /// patch init
+    init(from: Self, patch: AWSServiceConfig.Patch)
 }
 
 extension AWSService {
@@ -47,5 +49,19 @@ extension AWSService {
         logger: Logger = AWSClient.loggingDisabled
     ) -> EventLoopFuture<URL> {
         return self.client.signURL(url: url, httpMethod: httpMethod, headers: headers, expires: expires, serviceConfig: self.config, logger: logger)
+    }
+
+    func with(
+        middlewares: [AWSServiceMiddleware] = [],
+        timeout: TimeAmount? = nil,
+        byteBufferAllocator: ByteBufferAllocator? = nil,
+        options: AWSServiceConfig.Options? = nil
+    ) -> Self {
+        return Self(from: self, patch: .init(
+            middlewares: middlewares,
+            timeout: timeout,
+            byteBufferAllocator: byteBufferAllocator,
+            options: options
+        ))
     }
 }

--- a/Sources/SotoCore/AWSServiceConfig.swift
+++ b/Sources/SotoCore/AWSServiceConfig.swift
@@ -121,7 +121,7 @@ public final class AWSServiceConfig {
     /// - Parameters:
     ///   - patch: parameters to patch service config
     /// - Returns: New AWSServiceConfig
-    func with(patch: Patch) -> AWSServiceConfig {
+    public func with(patch: Patch) -> AWSServiceConfig {
         return AWSServiceConfig(
             region: self.region,
             amzTarget: self.amzTarget,
@@ -138,7 +138,7 @@ public final class AWSServiceConfig {
         )
     }
 
-    /// Service config parameters you can patch 
+    /// Service config parameters you can patch
     public struct Patch {
         let middlewares: [AWSServiceMiddleware]
         let timeout: TimeAmount?

--- a/Sources/SotoCore/AWSServiceConfig.swift
+++ b/Sources/SotoCore/AWSServiceConfig.swift
@@ -117,6 +117,47 @@ public final class AWSServiceConfig {
         }
     }
 
+    /// Return new version of serviceConfig with a modified parameters
+    /// - Parameters:
+    ///   - patch: parameters to patch service config
+    /// - Returns: New AWSServiceConfig
+    func with(patch: Patch) -> AWSServiceConfig {
+        return AWSServiceConfig(
+            region: self.region,
+            amzTarget: self.amzTarget,
+            service: self.service,
+            signingName: self.signingName,
+            serviceProtocol: self.serviceProtocol,
+            apiVersion: self.apiVersion,
+            endpoint: self.endpoint,
+            possibleErrorTypes: self.possibleErrorTypes,
+            middlewares: self.middlewares + patch.middlewares,
+            timeout: patch.timeout ?? self.timeout,
+            byteBufferAllocator: patch.byteBufferAllocator ?? self.byteBufferAllocator,
+            options: patch.options ?? self.options
+        )
+    }
+
+    /// Service config parameters you can patch 
+    public struct Patch {
+        let middlewares: [AWSServiceMiddleware]
+        let timeout: TimeAmount?
+        let byteBufferAllocator: ByteBufferAllocator?
+        let options: Options?
+
+        init(
+            middlewares: [AWSServiceMiddleware] = [],
+            timeout: TimeAmount? = nil,
+            byteBufferAllocator: ByteBufferAllocator? = nil,
+            options: AWSServiceConfig.Options? = nil
+        ) {
+            self.middlewares = middlewares
+            self.timeout = timeout
+            self.byteBufferAllocator = byteBufferAllocator
+            self.options = options
+        }
+    }
+
     /// Options used by client when processing requests
     public struct Options: OptionSet {
         public let rawValue: Int
@@ -128,5 +169,33 @@ public final class AWSServiceConfig {
         /// If you set a custom endpoint, s3 will choose path style addressing. With this paramteter you can force
         /// it to use virtual host style addressing
         public static let s3ForceVirtualHost = Options(rawValue: 1 << 0)
+    }
+
+    private init(
+        region: Region,
+        amzTarget: String?,
+        service: String,
+        signingName: String,
+        serviceProtocol: ServiceProtocol,
+        apiVersion: String,
+        endpoint: String,
+        possibleErrorTypes: [AWSErrorType.Type],
+        middlewares: [AWSServiceMiddleware],
+        timeout: TimeAmount,
+        byteBufferAllocator: ByteBufferAllocator,
+        options: Options
+    ) {
+        self.region = region
+        self.amzTarget = amzTarget
+        self.service = service
+        self.signingName = signingName
+        self.serviceProtocol = serviceProtocol
+        self.apiVersion = apiVersion
+        self.endpoint = endpoint
+        self.possibleErrorTypes = possibleErrorTypes
+        self.middlewares = middlewares
+        self.timeout = timeout
+        self.byteBufferAllocator = byteBufferAllocator
+        self.options = options
     }
 }

--- a/Tests/SotoCoreTests/AWSServiceTests.swift
+++ b/Tests/SotoCoreTests/AWSServiceTests.swift
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2020 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import SotoCore
+import SotoTestUtils
+import XCTest
+
+class AWSServiceTests: XCTestCase {
+    struct TestService: AWSService {
+        var client: AWSClient
+        var config: AWSServiceConfig
+
+        /// init
+        init(client: AWSClient, config: AWSServiceConfig) {
+            self.client = client
+            self.config = config
+        }
+        /// patch init
+        init(from: Self, patch: AWSServiceConfig.Patch) {
+            client = from.client
+            config = from.config.with(patch: patch)
+        }
+
+    }
+
+    func testRegion() {
+        let client = createAWSClient()
+        defer { XCTAssertNoThrow(try client.syncShutdown()) }
+        let serviceConfig = createServiceConfig(region: .apnortheast2)
+        let service = TestService(client: client, config: serviceConfig)
+        XCTAssertEqual(service.region, .apnortheast2)
+    }
+
+    func testEndpoint() {
+        let client = createAWSClient()
+        defer { XCTAssertNoThrow(try client.syncShutdown()) }
+        let serviceConfig = createServiceConfig(endpoint: "https://my-endpoint.com")
+        let service = TestService(client: client, config: serviceConfig)
+        XCTAssertEqual(service.endpoint, "https://my-endpoint.com")
+    }
+
+    func testWith() {
+        let client = createAWSClient()
+        defer { XCTAssertNoThrow(try client.syncShutdown()) }
+        let serviceConfig = createServiceConfig()
+        let service = TestService(client: client, config: serviceConfig)
+        let service2 = service.with(timeout: .seconds(2048), options: .init(rawValue: 0x67ff))
+        XCTAssertEqual(service2.config.timeout, .seconds(2048))
+        XCTAssertEqual(service2.config.options, .init(rawValue: 0x67ff))
+    }
+
+    func testWithMiddleware() {
+        struct TestMiddleware: AWSServiceMiddleware { }
+        let client = createAWSClient()
+        defer { XCTAssertNoThrow(try client.syncShutdown()) }
+        let serviceConfig = createServiceConfig()
+        let service = TestService(client: client, config: serviceConfig)
+        let service2 = service.with(middlewares: [TestMiddleware()])
+        XCTAssertNotNil(service2.config.middlewares.first {type(of: $0) == TestMiddleware.self})
+    }
+}

--- a/Tests/SotoCoreTests/AWSServiceTests.swift
+++ b/Tests/SotoCoreTests/AWSServiceTests.swift
@@ -26,12 +26,12 @@ class AWSServiceTests: XCTestCase {
             self.client = client
             self.config = config
         }
+
         /// patch init
         init(from: Self, patch: AWSServiceConfig.Patch) {
-            client = from.client
-            config = from.config.with(patch: patch)
+            self.client = from.client
+            self.config = from.config.with(patch: patch)
         }
-
     }
 
     func testRegion() {
@@ -55,18 +55,18 @@ class AWSServiceTests: XCTestCase {
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
         let serviceConfig = createServiceConfig()
         let service = TestService(client: client, config: serviceConfig)
-        let service2 = service.with(timeout: .seconds(2048), options: .init(rawValue: 0x67ff))
+        let service2 = service.with(timeout: .seconds(2048), options: .init(rawValue: 0x67FF))
         XCTAssertEqual(service2.config.timeout, .seconds(2048))
-        XCTAssertEqual(service2.config.options, .init(rawValue: 0x67ff))
+        XCTAssertEqual(service2.config.options, .init(rawValue: 0x67FF))
     }
 
     func testWithMiddleware() {
-        struct TestMiddleware: AWSServiceMiddleware { }
+        struct TestMiddleware: AWSServiceMiddleware {}
         let client = createAWSClient()
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
         let serviceConfig = createServiceConfig()
         let service = TestService(client: client, config: serviceConfig)
         let service2 = service.with(middlewares: [TestMiddleware()])
-        XCTAssertNotNil(service2.config.middlewares.first {type(of: $0) == TestMiddleware.self})
+        XCTAssertNotNil(service2.config.middlewares.first { type(of: $0) == TestMiddleware.self })
     }
 }


### PR DESCRIPTION
AWSService.with(middlewares:timeout:byteBufferAllocator:options) returns a new version of the AWSService with edited attributes