### PR TITLE
Query encoder cleanup/performance improvement

### DIFF
--- a/Sources/SotoCore/Doc/AWSShape+Encoder.swift
+++ b/Sources/SotoCore/Doc/AWSShape+Encoder.swift
@@ -32,16 +32,14 @@ internal extension AWSEncodableShape {
     }
 
     /// Encode AWSShape as a query array
-    /// - Parameter flattenArrays: should all arrays be flattened
-    func encodeAsQuery(with keys: [String: Any]) throws -> String? {
+    func encodeAsQuery(with keys: [String: String]) throws -> String? {
         var encoder = QueryEncoder()
         encoder.additionalKeys = keys
         return try encoder.encode(self)
     }
 
     /// Encode AWSShape as a query array
-    /// - Parameter flattenArrays: should all arrays be flattened
-    func encodeAsQueryForEC2(with keys: [String: Any]) throws -> String? {
+    func encodeAsQueryForEC2(with keys: [String: String]) throws -> String? {
         var encoder = QueryEncoder()
         encoder.additionalKeys = keys
         encoder.ec2 = true

--- a/Sources/SotoCore/Doc/AWSShape+Encoder.swift
+++ b/Sources/SotoCore/Doc/AWSShape+Encoder.swift
@@ -33,15 +33,17 @@ internal extension AWSEncodableShape {
 
     /// Encode AWSShape as a query array
     /// - Parameter flattenArrays: should all arrays be flattened
-    func encodeAsQuery() throws -> [String: Any] {
-        let encoder = QueryEncoder()
+    func encodeAsQuery(with keys: [String: Any]) throws -> String? {
+        var encoder = QueryEncoder()
+        encoder.additionalKeys = keys
         return try encoder.encode(self)
     }
 
     /// Encode AWSShape as a query array
     /// - Parameter flattenArrays: should all arrays be flattened
-    func encodeAsQueryForEC2() throws -> [String: Any] {
-        let encoder = QueryEncoder()
+    func encodeAsQueryForEC2(with keys: [String: Any]) throws -> String? {
+        var encoder = QueryEncoder()
+        encoder.additionalKeys = keys
         encoder.ec2 = true
         return try encoder.encode(self)
     }

--- a/Sources/SotoCore/Message/AWSRequest.swift
+++ b/Sources/SotoCore/Message/AWSRequest.swift
@@ -233,7 +233,7 @@ extension AWSRequest {
             if let query = try input.encodeAsQuery(with: ["Action": operationName, "Version": configuration.apiVersion]) {
                 body = .text(query)
             }
-            
+
         case .ec2:
             if let query = try input.encodeAsQueryForEC2(with: ["Action": operationName, "Version": configuration.apiVersion]) {
                 body = .text(query)

--- a/Sources/SotoXML/XMLDecoder.swift
+++ b/Sources/SotoXML/XMLDecoder.swift
@@ -20,7 +20,7 @@ import class Foundation.NSNumber
 import struct Foundation.URL
 
 /// The wrapper class for decoding Codable classes from XMLNodes
-public final class XMLDecoder {
+public struct XMLDecoder {
     /// The strategy to use for decoding `Data` values.
     public enum DataDecodingStrategy {
         /// Decode the `Data` from a Base64-encoded string.

--- a/Sources/SotoXML/XMLEncoder.swift
+++ b/Sources/SotoXML/XMLEncoder.swift
@@ -18,7 +18,7 @@ import class Foundation.DateFormatter
 import struct Foundation.URL
 
 /// The wrapper class for encoding Codable classes to XMLElements
-public final class XMLEncoder {
+public struct XMLEncoder {
     /// The strategy to use for encoding `Data` values.
     public enum DataEncodingStrategy {
         /// Encoded the `Data` as a Base64-encoded string. This is the default strategy.

--- a/Tests/SotoCoreTests/QueryEncoderTests.swift
+++ b/Tests/SotoCoreTests/QueryEncoderTests.swift
@@ -22,7 +22,6 @@ class QueryEncoderTests: XCTestCase {
     func testQuery<Input: Encodable>(_ value: Input, query: String) {
         do {
             let query2 = try QueryEncoder().encode(value)
-            //let query2 = self.queryString(dictionary: queryDict)
             XCTAssertEqual(query2, query)
         } catch {
             XCTFail("\(error)")

--- a/Tests/SotoCoreTests/QueryEncoderTests.swift
+++ b/Tests/SotoCoreTests/QueryEncoderTests.swift
@@ -19,19 +19,10 @@ import XCTest
 class QueryEncoderTests: XCTestCase {
     @EnvironmentVariable("ENABLE_TIMING_TESTS", default: true) static var enableTimingTests: Bool
 
-    func queryString(dictionary: [String: Any]) -> String? {
-        var components = URLComponents()
-        components.queryItems = dictionary.map { URLQueryItem(name: $0.key, value: String(describing: $0.value)) }.sorted(by: { $0.name < $1.name })
-        if components.queryItems != nil, let url = components.url {
-            return url.query
-        }
-        return nil
-    }
-
     func testQuery<Input: Encodable>(_ value: Input, query: String) {
         do {
-            let queryDict = try QueryEncoder().encode(value)
-            let query2 = self.queryString(dictionary: queryDict)
+            let query2 = try QueryEncoder().encode(value)
+            //let query2 = self.queryString(dictionary: queryDict)
             XCTAssertEqual(query2, query)
         } catch {
             XCTFail("\(error)")
@@ -224,8 +215,7 @@ class QueryEncoderTests: XCTestCase {
         }
         let data = Data("Testing".utf8)
         let test = Test(a: data)
-        let result = self.queryString(dictionary: ["a": data.base64EncodedString()])!
-        self.testQuery(test, query: result)
+        self.testQuery(test, query: "a=VGVzdGluZw%3D%3D")
     }
 
     func testEC2Encode() {
@@ -237,12 +227,11 @@ class QueryEncoderTests: XCTestCase {
         }
         do {
             let value = Test(object: Test2(data: "Hello"))
-            let queryEncoder = QueryEncoder()
+            var queryEncoder = QueryEncoder()
             queryEncoder.ec2 = true
-            let queryDict = try queryEncoder.encode(value)
-            let queryAsString = self.queryString(dictionary: queryDict)
+            let query = try queryEncoder.encode(value)
 
-            XCTAssertEqual(queryAsString, "Object.Data=Hello")
+            XCTAssertEqual(query, "Object.Data=Hello")
         } catch {
             XCTFail("\(error)")
         }


### PR DESCRIPTION
Looking to improve performance by removing temporary dictionary containing query keys and values. QueryEncoder now generates the query string and manages the encoding of the query keys. Haven't completely removed temporary dictionary as I need to sort the query values by key, but changed this to an array of (key, value) tuples. This is all internal to QueryEncoder now so allows us to spend more time on optimising this.

To allow QueryEncoder to output final string, added additional keys to prime the encoder with (add "Action" and "Version" fields with this). Also verified there are no query based GET operations that have a body so can remove the test for this. 