### PR TITLE
Add Array.reduce style paginate function.

### DIFF
--- a/Sources/SotoCore/AWSClient+Paginate.swift
+++ b/Sources/SotoCore/AWSClient+Paginate.swift
@@ -91,8 +91,8 @@ extension AWSClient {
         logger: Logger = AWSClient.loggingDisabled,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
-        paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, on: eventLoop, logger: logger) { _, output, eventLoop in
-            return onPage(output, eventLoop).map { rt in (rt, ())}
+        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, on: eventLoop, logger: logger) { _, output, eventLoop in
+            return onPage(output, eventLoop).map { rt in (rt, ()) }
         }
     }
 
@@ -169,8 +169,8 @@ extension AWSClient {
         logger: Logger = AWSClient.loggingDisabled,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
-        paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, on: eventLoop, logger: logger) { _, output, eventLoop in
-            return onPage(output, eventLoop).map { rt in (rt, ())}
+        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, on: eventLoop, logger: logger) { _, output, eventLoop in
+            return onPage(output, eventLoop).map { rt in (rt, ()) }
         }
     }
 
@@ -247,9 +247,8 @@ extension AWSClient {
         logger: Logger = AWSClient.loggingDisabled,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
-        paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, on: eventLoop, logger: logger) { _, output, eventLoop in
-            return onPage(output, eventLoop).map { rt in (rt, ())}
+        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, on: eventLoop, logger: logger) { _, output, eventLoop in
+            return onPage(output, eventLoop).map { rt in (rt, ()) }
         }
     }
 }
-

--- a/Sources/SotoCore/AWSClient+Paginate.swift
+++ b/Sources/SotoCore/AWSClient+Paginate.swift
@@ -25,35 +25,41 @@ public protocol AWSPaginateToken: AWSShape {
 extension AWSClient {
     /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
     /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
-    /// the next block. This function loads each block and calls a closure with each block as parameter.
+    /// the next block. This function loads each block and calls a closure with each block as parameter. This function returns
+    /// the result of combining all of these blocks using the given closure,
     ///
     /// - Parameters:
     ///   - input: Input for request
+    ///   - initialValue: The value to use as the initial accumulating value. `initialValue` is passed to `onPage` the first time it is called.
     ///   - command: Command to be paginated
     ///   - tokenKey: The name of token in the response object to continue pagination
-    ///   - onPage: closure called with each block of entries
-    public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
+    ///   - eventLoop: EventLoop to run this process on
+    ///   - logger: Logger used flot logging
+    ///   - onPage: closure called with each block of entries. It combines an accumulating result with the contents of response from the call to AWS. This combined result is then returned
+    ///         along with a boolean indicating if the paginate operation should continue.
+    public func paginate<Input: AWSPaginateToken, Output: AWSShape, Result>(
         input: Input,
+        initialValue: Result,
         command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         on eventLoop: EventLoop? = nil,
         logger: Logger = AWSClient.loggingDisabled,
-        onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
-    ) -> EventLoopFuture<Void> {
+        onPage: @escaping (Result, Output, EventLoop) -> EventLoopFuture<(Bool, Result)>
+    ) -> EventLoopFuture<Result> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
-        let promise = eventLoop.makePromise(of: Void.self)
+        let promise = eventLoop.makePromise(of: Result.self)
 
-        func paginatePart(input: Input) {
+        func paginatePart(input: Input, currentValue: Result) {
             let responseFuture = command(input, eventLoop, logger)
                 .flatMap { response in
-                    return onPage(response, eventLoop)
-                        .map { (rt) -> Void in
-                            guard rt == true else { return promise.succeed(()) }
+                    return onPage(currentValue, response, eventLoop)
+                        .map { continuePaginate, result -> Void in
+                            guard continuePaginate == true else { return promise.succeed(result) }
                             // get next block token and construct a new input with this token
-                            guard let token = response[keyPath: tokenKey] else { return promise.succeed(()) }
+                            guard let token = response[keyPath: tokenKey] else { return promise.succeed(result) }
 
                             let input = input.usingPaginationToken(token)
-                            paginatePart(input: input)
+                            paginatePart(input: input, currentValue: result)
                         }
                 }
             responseFuture.whenFailure { error in
@@ -61,7 +67,7 @@ extension AWSClient {
             }
         }
 
-        paginatePart(input: input)
+        paginatePart(input: input, currentValue: initialValue)
 
         return promise.futureResult
     }
@@ -74,7 +80,86 @@ extension AWSClient {
     ///   - input: Input for request
     ///   - command: Command to be paginated
     ///   - tokenKey: The name of token in the response object to continue pagination
-    ///   - onPage: closure called with each block of entries
+    ///   - eventLoop: EventLoop to run this process on
+    ///   - logger: Logger used flot logging
+    ///   - onPage: closure called with each block of entries. Returns boolean indicating whether we should continue.
+    public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
+        input: Input,
+        command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
+        tokenKey: KeyPath<Output, Input.Token?>,
+        on eventLoop: EventLoop? = nil,
+        logger: Logger = AWSClient.loggingDisabled,
+        onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
+    ) -> EventLoopFuture<Void> {
+        paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, on: eventLoop, logger: logger) { _, output, eventLoop in
+            return onPage(output, eventLoop).map { rt in (rt, ())}
+        }
+    }
+
+    /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
+    /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
+    /// the next block. This function loads each block and calls a closure with each block as parameter. This function returns
+    /// the result of combining all of these blocks using the given closure,
+    ///
+    /// - Parameters:
+    ///   - input: Input for request
+    ///   - initialValue: The value to use as the initial accumulating value. `initialValue` is passed to `onPage` the first time it is called.
+    ///   - command: Command to be paginated
+    ///   - tokenKey: The name of token in the response object to continue pagination
+    ///   - moreResultsKey: The KeyPath for the member of the output that indicates whether we should ask for more data
+    ///   - eventLoop: EventLoop to run this process on
+    ///   - logger: Logger used flot logging
+    ///   - onPage: closure called with each block of entries. It combines an accumulating result with the contents of response from the call to AWS. This combined result is then returned
+    ///         along with a boolean indicating if the paginate operation should continue.
+    public func paginate<Input: AWSPaginateToken, Output: AWSShape, Result>(
+        input: Input,
+        initialValue: Result,
+        command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
+        tokenKey: KeyPath<Output, Input.Token?>,
+        moreResultsKey: KeyPath<Output, Bool>,
+        on eventLoop: EventLoop? = nil,
+        logger: Logger = AWSClient.loggingDisabled,
+        onPage: @escaping (Result, Output, EventLoop) -> EventLoopFuture<(Bool, Result)>
+    ) -> EventLoopFuture<Result> {
+        let eventLoop = eventLoop ?? eventLoopGroup.next()
+        let promise = eventLoop.makePromise(of: Result.self)
+
+        func paginatePart(input: Input, currentValue: Result) {
+            let responseFuture = command(input, eventLoop, logger)
+                .flatMap { response in
+                    return onPage(currentValue, response, eventLoop)
+                        .map { continuePaginate, result -> Void in
+                            guard continuePaginate == true else { return promise.succeed(result) }
+                            // get next block token and construct a new input with this token
+                            guard let token = response[keyPath: tokenKey],
+                                response[keyPath: moreResultsKey] else { return promise.succeed(result) }
+
+                            let input = input.usingPaginationToken(token)
+                            paginatePart(input: input, currentValue: result)
+                        }
+                }
+            responseFuture.whenFailure { error in
+                promise.fail(error)
+            }
+        }
+
+        paginatePart(input: input, currentValue: initialValue)
+
+        return promise.futureResult
+    }
+
+    /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
+    /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
+    /// the next block. This function loads each block and calls a closure with each block as parameter.
+    ///
+    /// - Parameters:
+    ///   - input: Input for request
+    ///   - command: Command to be paginated
+    ///   - tokenKey: The name of token in the response object to continue pagination
+    ///   - moreResultsKey: The KeyPath for the member of the output that indicates whether we should ask for more data
+    ///   - eventLoop: EventLoop to run this process on
+    ///   - logger: Logger used flot logging
+    ///   - onPage: closure called with each block of entries. Returns boolean indicating whether we should continue.
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
         command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
@@ -84,21 +169,51 @@ extension AWSClient {
         logger: Logger = AWSClient.loggingDisabled,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
-        let eventLoop = eventLoop ?? eventLoopGroup.next()
-        let promise = eventLoop.makePromise(of: Void.self)
+        paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, on: eventLoop, logger: logger) { _, output, eventLoop in
+            return onPage(output, eventLoop).map { rt in (rt, ())}
+        }
+    }
 
-        func paginatePart(input: Input) {
+    /// If an AWS command is returning an arbituary sized array sometimes it adds support for paginating this array
+    /// ie it will return the array in blocks of a defined size, each block also includes a token which can be used to access
+    /// the next block. This function loads each block and calls a closure with each block as parameter. This function returns
+    /// the result of combining all of these blocks using the given closure,
+    ///
+    /// - Parameters:
+    ///   - input: Input for request
+    ///   - initialValue: The value to use as the initial accumulating value. `initialValue` is passed to `onPage` the first time it is called.
+    ///   - command: Command to be paginated
+    ///   - tokenKey: The name of token in the response object to continue pagination
+    ///   - moreResultsKey: The KeyPath for the member of the output that indicates whether we should ask for more data
+    ///   - eventLoop: EventLoop to run this process on
+    ///   - logger: Logger used flot logging
+    ///   - onPage: closure called with each block of entries. It combines an accumulating result with the contents of response from the call to AWS. This combined result is then returned
+    ///         along with a boolean indicating if the paginate operation should continue.
+    public func paginate<Input: AWSPaginateToken, Output: AWSShape, Result>(
+        input: Input,
+        initialValue: Result,
+        command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
+        tokenKey: KeyPath<Output, Input.Token?>,
+        moreResultsKey: KeyPath<Output, Bool?>,
+        on eventLoop: EventLoop? = nil,
+        logger: Logger = AWSClient.loggingDisabled,
+        onPage: @escaping (Result, Output, EventLoop) -> EventLoopFuture<(Bool, Result)>
+    ) -> EventLoopFuture<Result> {
+        let eventLoop = eventLoop ?? eventLoopGroup.next()
+        let promise = eventLoop.makePromise(of: Result.self)
+
+        func paginatePart(input: Input, currentValue: Result) {
             let responseFuture = command(input, eventLoop, logger)
                 .flatMap { response in
-                    return onPage(response, eventLoop)
-                        .map { (rt) -> Void in
-                            guard rt == true else { return promise.succeed(()) }
+                    return onPage(currentValue, response, eventLoop)
+                        .map { continuePaginate, result -> Void in
+                            guard continuePaginate == true else { return promise.succeed(result) }
                             // get next block token and construct a new input with this token
                             guard let token = response[keyPath: tokenKey],
-                                response[keyPath: moreResultsKey] else { return promise.succeed(()) }
+                                response[keyPath: moreResultsKey] == true else { return promise.succeed(result) }
 
                             let input = input.usingPaginationToken(token)
-                            paginatePart(input: input)
+                            paginatePart(input: input, currentValue: result)
                         }
                 }
             responseFuture.whenFailure { error in
@@ -106,7 +221,7 @@ extension AWSClient {
             }
         }
 
-        paginatePart(input: input)
+        paginatePart(input: input, currentValue: initialValue)
 
         return promise.futureResult
     }
@@ -119,7 +234,10 @@ extension AWSClient {
     ///   - input: Input for request
     ///   - command: Command to be paginated
     ///   - tokenKey: The name of token in the response object to continue pagination
-    ///   - onPage: closure called with each block of entries
+    ///   - moreResultsKey: The KeyPath for the member of the output that indicates whether we should ask for more data
+    ///   - eventLoop: EventLoop to run this process on
+    ///   - logger: Logger used flot logging
+    ///   - onPage: closure called with each block of entries. Returns boolean indicating whether we should continue.
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
         command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
@@ -129,30 +247,9 @@ extension AWSClient {
         logger: Logger = AWSClient.loggingDisabled,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
-        let eventLoop = eventLoop ?? eventLoopGroup.next()
-        let promise = eventLoop.makePromise(of: Void.self)
-
-        func paginatePart(input: Input) {
-            let responseFuture = command(input, eventLoop, logger)
-                .flatMap { response in
-                    return onPage(response, eventLoop)
-                        .map { (rt) -> Void in
-                            guard rt == true else { return promise.succeed(()) }
-                            // get next block token and construct a new input with this token
-                            guard let token = response[keyPath: tokenKey],
-                                response[keyPath: moreResultsKey] == true else { return promise.succeed(()) }
-
-                            let input = input.usingPaginationToken(token)
-                            paginatePart(input: input)
-                        }
-                }
-            responseFuture.whenFailure { error in
-                promise.fail(error)
-            }
+        paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, on: eventLoop, logger: logger) { _, output, eventLoop in
+            return onPage(output, eventLoop).map { rt in (rt, ())}
         }
-
-        paginatePart(input: input)
-
-        return promise.futureResult
     }
 }
+


### PR DESCRIPTION
A lot of the time paginate fuctions are going to be used in the following way
```
var files: [String] = []
_ = try listFilesPaginator(input) { response, eventLoop in
    files.append(response.files)
    return eventLoop.makeSucceededFuture(true)
}.wait()
```
This change allows you to do the following which is cleaner
```
let files = try listFilesPaginator(input, []) { current, response, eventLoop in
    return eventLoop.makeSucceededFuture((true, current + response.files))
}.wait() 
```

I also re-implemented the original functions using new `reduce` style functions