### PR TITLE
Add additional fields to AWSErrorContext

### DIFF
--- a/Sources/SotoCore/Errors/Error.swift
+++ b/Sources/SotoCore/Errors/Error.swift
@@ -39,11 +39,18 @@ public struct AWSErrorContext {
     public let message: String
     public let responseCode: HTTPResponseStatus
     public let headers: HTTPHeaders
+    public let additionalFields: [String: String]
 
-    internal init(message: String, responseCode: HTTPResponseStatus, headers: HTTPHeaders = [:]) {
+    internal init(
+        message: String,
+        responseCode: HTTPResponseStatus,
+        headers: HTTPHeaders = [:],
+        additionalFields: [String: String] = [:]
+    ) {
         self.message = message
         self.responseCode = responseCode
         self.headers = headers
+        self.additionalFields = additionalFields
     }
 }
 

--- a/Sources/SotoCore/Message/AWSResponse.swift
+++ b/Sources/SotoCore/Message/AWSResponse.swift
@@ -261,7 +261,7 @@ public struct AWSResponse {
 
         return nil
     }
-    
+
     /// Error used by XML output
     private struct XMLQueryError: Codable, APIError {
         var code: String?
@@ -273,7 +273,7 @@ public struct AWSResponse {
             let container = try decoder.container(keyedBy: ErrorCodingKey.self)
             self.code = try container.decodeIfPresent(String.self, forKey: .init("Code"))
             self.message = try container.decode(String.self, forKey: .init("Message"))
-            
+
             var additionalFields: [String: String] = [:]
             for key in container.allKeys {
                 guard key.stringValue != "Code", key.stringValue != "Message" else { continue }
@@ -294,7 +294,7 @@ public struct AWSResponse {
             let container = try decoder.container(keyedBy: ErrorCodingKey.self)
             self.code = try container.decodeIfPresent(String.self, forKey: .init("__type"))
             self.message = try container.decodeIfPresent(String.self, forKey: .init("message")) ?? container.decode(String.self, forKey: .init("Message"))
-            
+
             var additionalFields: [String: String] = [:]
             for key in container.allKeys {
                 guard key.stringValue != "__type", key.stringValue != "message", key.stringValue != "Message" else { continue }
@@ -315,7 +315,7 @@ public struct AWSResponse {
             let container = try decoder.container(keyedBy: ErrorCodingKey.self)
             self.code = try container.decodeIfPresent(String.self, forKey: .init("code"))
             self.message = try container.decodeIfPresent(String.self, forKey: .init("message")) ?? container.decode(String.self, forKey: .init("Message"))
-            
+
             var additionalFields: [String: String] = [:]
             for key in container.allKeys {
                 guard key.stringValue != "code", key.stringValue != "message", key.stringValue != "Message" else { continue }
@@ -324,7 +324,7 @@ public struct AWSResponse {
             self.additionalFields = additionalFields
         }
     }
-    
+
     /// CodingKey used when decoding Errors
     private struct ErrorCodingKey: CodingKey {
         var stringValue: String
@@ -334,10 +334,12 @@ public struct AWSResponse {
             self.stringValue = stringValue
             self.intValue = nil
         }
+
         init?(stringValue: String) {
             self.stringValue = stringValue
             self.intValue = nil
         }
+
         init?(intValue: Int) {
             return nil
         }

--- a/Sources/SotoCore/Message/AWSResponse.swift
+++ b/Sources/SotoCore/Message/AWSResponse.swift
@@ -239,7 +239,8 @@ public struct AWSResponse {
             let context = AWSErrorContext(
                 message: errorMessage.message,
                 responseCode: self.status,
-                headers: .init(headers.map { ($0.key, String(describing: $0.value)) })
+                headers: .init(headers.map { ($0.key, String(describing: $0.value)) }),
+                additionalFields: errorMessage.additionalFields
             )
 
             if let errorType = serviceConfig.errorType {
@@ -260,83 +261,91 @@ public struct AWSResponse {
 
         return nil
     }
-
+    
+    /// Error used by XML output
     private struct XMLQueryError: Codable, APIError {
         var code: String?
-        var message: String
-        var additionalFields: [String: String]
+        let message: String
+        let additionalFields: [String: String]
 
         init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.code = try container.decodeIfPresent(String.self, forKey: .code)
-            self.message = try container.decode(String.self, forKey: .message)
+            // use `ErrorCodingKey` so we get extract additional keys from `container.allKeys`
+            let container = try decoder.container(keyedBy: ErrorCodingKey.self)
+            self.code = try container.decodeIfPresent(String.self, forKey: .init("Code"))
+            self.message = try container.decode(String.self, forKey: .init("Message"))
             
             var additionalFields: [String: String] = [:]
             for key in container.allKeys {
-                guard key != .code, key != .message else { continue }
+                guard key.stringValue != "Code", key.stringValue != "Message" else { continue }
                 additionalFields[key.stringValue] = try container.decodeIfPresent(String.self, forKey: key)
             }
             self.additionalFields = additionalFields
         }
-
-        private enum CodingKeys: String, CodingKey {
-            case code = "Code"
-            case message = "Message"
-        }
     }
 
+    /// Error used by JSON output
     private struct JSONError: Decodable, APIError {
         var code: String?
-        var message: String
-        var additionalFields: [String: String]
+        let message: String
+        let additionalFields: [String: String]
 
         init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.code = try container.decode(String?.self, forKey: .code)
-            self.message = try container.decodeIfPresent(String.self, forKey: .message) ?? container.decode(String.self, forKey: .Message)
+            // use `ErrorCodingKey` so we get extract additional keys from `container.allKeys`
+            let container = try decoder.container(keyedBy: ErrorCodingKey.self)
+            self.code = try container.decodeIfPresent(String.self, forKey: .init("__type"))
+            self.message = try container.decodeIfPresent(String.self, forKey: .init("message")) ?? container.decode(String.self, forKey: .init("Message"))
             
             var additionalFields: [String: String] = [:]
             for key in container.allKeys {
-                guard key != .code, key != .message, key != .Message else { continue }
+                guard key.stringValue != "__type", key.stringValue != "message", key.stringValue != "Message" else { continue }
                 additionalFields[key.stringValue] = try container.decodeIfPresent(String.self, forKey: key)
             }
             self.additionalFields = additionalFields
-        }
-
-        private enum CodingKeys: String, CodingKey {
-            case code = "__type"
-            case message
-            case Message
         }
     }
 
+    /// Error used by REST JSON output
     private struct RESTJSONError: Decodable, APIError {
         var code: String?
-        var message: String
-        var additionalFields: [String: String]
+        let message: String
+        let additionalFields: [String: String]
 
         init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.code = try container.decodeIfPresent(String.self, forKey: .code)
-            self.message = try container.decodeIfPresent(String.self, forKey: .message) ?? container.decode(String.self, forKey: .Message)
+            // use `ErrorCodingKey` so we get extract additional keys from `container.allKeys`
+            let container = try decoder.container(keyedBy: ErrorCodingKey.self)
+            self.code = try container.decodeIfPresent(String.self, forKey: .init("code"))
+            self.message = try container.decodeIfPresent(String.self, forKey: .init("message")) ?? container.decode(String.self, forKey: .init("Message"))
             
             var additionalFields: [String: String] = [:]
             for key in container.allKeys {
-                guard key != .code, key != .message, key != .Message else { continue }
+                guard key.stringValue != "code", key.stringValue != "message", key.stringValue != "Message" else { continue }
                 additionalFields[key.stringValue] = try container.decodeIfPresent(String.self, forKey: key)
             }
             self.additionalFields = additionalFields
         }
+    }
+    
+    /// CodingKey used when decoding Errors
+    private struct ErrorCodingKey: CodingKey {
+        var stringValue: String
+        var intValue: Int?
 
-        private enum CodingKeys: String, CodingKey {
-            case code
-            case message
-            case Message
+        init(_ stringValue: String) {
+            self.stringValue = stringValue
+            self.intValue = nil
+        }
+        init?(stringValue: String) {
+            self.stringValue = stringValue
+            self.intValue = nil
+        }
+        init?(intValue: Int) {
+            return nil
         }
     }
 }
 
 private protocol APIError {
     var code: String? { get set }
-    var message: String { get set }
+    var message: String { get }
+    var additionalFields: [String: String] { get }
 }

--- a/Sources/SotoCore/Message/AWSResponse.swift
+++ b/Sources/SotoCore/Message/AWSResponse.swift
@@ -264,6 +264,20 @@ public struct AWSResponse {
     private struct XMLQueryError: Codable, APIError {
         var code: String?
         var message: String
+        var additionalFields: [String: String]
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.code = try container.decodeIfPresent(String.self, forKey: .code)
+            self.message = try container.decode(String.self, forKey: .message)
+            
+            var additionalFields: [String: String] = [:]
+            for key in container.allKeys {
+                guard key != .code, key != .message else { continue }
+                additionalFields[key.stringValue] = try container.decodeIfPresent(String.self, forKey: key)
+            }
+            self.additionalFields = additionalFields
+        }
 
         private enum CodingKeys: String, CodingKey {
             case code = "Code"
@@ -274,11 +288,19 @@ public struct AWSResponse {
     private struct JSONError: Decodable, APIError {
         var code: String?
         var message: String
+        var additionalFields: [String: String]
 
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.code = try container.decode(String?.self, forKey: .code)
             self.message = try container.decodeIfPresent(String.self, forKey: .message) ?? container.decode(String.self, forKey: .Message)
+            
+            var additionalFields: [String: String] = [:]
+            for key in container.allKeys {
+                guard key != .code, key != .message, key != .Message else { continue }
+                additionalFields[key.stringValue] = try container.decodeIfPresent(String.self, forKey: key)
+            }
+            self.additionalFields = additionalFields
         }
 
         private enum CodingKeys: String, CodingKey {
@@ -291,11 +313,19 @@ public struct AWSResponse {
     private struct RESTJSONError: Decodable, APIError {
         var code: String?
         var message: String
+        var additionalFields: [String: String]
 
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.code = try container.decodeIfPresent(String.self, forKey: .code)
             self.message = try container.decodeIfPresent(String.self, forKey: .message) ?? container.decode(String.self, forKey: .Message)
+            
+            var additionalFields: [String: String] = [:]
+            for key in container.allKeys {
+                guard key != .code, key != .message, key != .Message else { continue }
+                additionalFields[key.stringValue] = try container.decodeIfPresent(String.self, forKey: key)
+            }
+            self.additionalFields = additionalFields
         }
 
         private enum CodingKeys: String, CodingKey {

--- a/Tests/SotoCoreTests/AWSResponseTests.swift
+++ b/Tests/SotoCoreTests/AWSResponseTests.swift
@@ -224,7 +224,7 @@ class AWSResponseTests: XCTestCase {
         let response = AWSHTTPResponseImpl(
             status: .notFound,
             headers: HTTPHeaders(),
-            bodyData: #"{"__type":"ResourceNotFoundException", "Message": "Donald Where's Your Troosers?", "fault": "client"}"#.data(using: .utf8)!
+            bodyData: #"{"__type":"ResourceNotFoundException", "Message": "Donald Where's Your Troosers?", "fault": "client"}"# .data(using: .utf8)!
         )
         let service = createServiceConfig(serviceProtocol: .json(version: "1.1"), errorType: ServiceErrorType.self)
 
@@ -241,7 +241,7 @@ class AWSResponseTests: XCTestCase {
         let response = AWSHTTPResponseImpl(
             status: .notFound,
             headers: ["x-amzn-errortype": "ResourceNotFoundException"],
-            bodyData: Data(#"{"message": "Donald Where's Your Troosers?", "Fault": "Client"}"#.utf8)
+            bodyData: Data(#"{"message": "Donald Where's Your Troosers?", "Fault": "Client"}"# .utf8)
         )
         let service = createServiceConfig(serviceProtocol: .restjson, errorType: ServiceErrorType.self)
 
@@ -259,7 +259,7 @@ class AWSResponseTests: XCTestCase {
         let response = AWSHTTPResponseImpl(
             status: .notFound,
             headers: ["x-amzn-errortype": "ResourceNotFoundException"],
-            bodyData: Data(#"{"Message": "Donald Where's Your Troosers?"}"#.utf8)
+            bodyData: Data(#"{"Message": "Donald Where's Your Troosers?"}"# .utf8)
         )
         let service = createServiceConfig(serviceProtocol: .restjson, errorType: ServiceErrorType.self)
 


### PR DESCRIPTION
Parse errors for additional fields we don't know about and place them in a `additionalFields: [String: String]` member of `AWSErrorContext`