### PR TITLE
Process AWS Errors before called RetryPolicy.getRetryWaitTime

### DIFF
--- a/Sources/SotoCore/RetryPolicy.swift
+++ b/Sources/SotoCore/RetryPolicy.swift
@@ -82,7 +82,8 @@ extension StandardRetryPolicy {
                 // server error or too many requests
                 if (500...).contains(context.responseCode.code) ||
                     context.responseCode.code == 429 ||
-                    error.errorCode == AWSClientError.throttling.errorCode {
+                    error.errorCode == AWSClientError.throttling.errorCode
+                {
                     return .retry(wait: calculateRetryWaitTime(attempt: attempt))
                 }
             }

--- a/Sources/SotoCore/RetryPolicy.swift
+++ b/Sources/SotoCore/RetryPolicy.swift
@@ -73,10 +73,12 @@ extension StandardRetryPolicy {
         guard attempt < maxRetries else { return .dontRetry }
 
         switch error {
-        // server error or too many requests
-        case let responseError as AWSClient.HTTPResponseError:
-            if (500...).contains(responseError.response.status.code) || responseError.response.status.code == 429 {
-                return .retry(wait: calculateRetryWaitTime(attempt: attempt))
+        case let awsError as AWSErrorType:
+            if let context = awsError.context {
+                // server error or too many requests
+                if (500...).contains(context.responseCode.code) || context.responseCode.code == 429 {
+                    return .retry(wait: calculateRetryWaitTime(attempt: attempt))
+                }
             }
             return .dontRetry
         case is NIOConnectionError:

--- a/Sources/SotoCore/RetryPolicy.swift
+++ b/Sources/SotoCore/RetryPolicy.swift
@@ -75,6 +75,10 @@ extension StandardRetryPolicy {
         switch error {
         case let awsError as AWSErrorType:
             if let context = awsError.context {
+                // if response has a "Retry-After" header then use that
+                if let retryAfterString = context.headers["Retry-After"].first, let retryAfter = Int64(retryAfterString) {
+                    return .retry(wait: .seconds(retryAfter))
+                }
                 // server error or too many requests
                 if (500...).contains(context.responseCode.code) || context.responseCode.code == 429 {
                     return .retry(wait: calculateRetryWaitTime(attempt: attempt))


### PR DESCRIPTION
This means we can make retry decisions based on a `AWSErrorType` instead of a raw HTTP Response error