### PR TITLE
Replace logger with baggage context for AWSClient v2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
             .byName(name: "SotoXML"),
             .byName(name: "INIParser"),
             .product(name: "AsyncHTTPClient", package: "async-http-client"),
-            .product(name: "BaggageContext", package: "swift-context"),
+            .byName(name: "BaggageContext"),
             .product(name: "Logging", package: "swift-log"),
             .product(name: "Metrics", package: "swift-metrics"),
             .product(name: "NIO", package: "swift-nio"),
@@ -52,7 +52,7 @@ let package = Package(
         ]),
         .target(name: "SotoTestUtils", dependencies: [
             .byName(name: "SotoCore"),
-            .product(name: "BaggageContext", package: "swift-context"),
+            .byName(name: "BaggageContext"),
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
             .product(name: "NIOFoundationCompat", package: "swift-nio"),

--- a/Package.swift
+++ b/Package.swift
@@ -28,14 +28,16 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMajor(from: "2.7.2")),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.2.0")),
+        .package(url: "https://github.com/slashmo/gsoc-swift-baggage-context.git", from: "0.5.0"),
     ],
     targets: [
         .target(name: "SotoCore", dependencies: [
             .byName(name: "SotoSignerV4"),
             .byName(name: "SotoXML"),
             .byName(name: "INIParser"),
-            .product(name: "Logging", package: "swift-log"),
             .product(name: "AsyncHTTPClient", package: "async-http-client"),
+            .product(name: "BaggageContext", package: "swift-context"),
+            .product(name: "Logging", package: "swift-log"),
             .product(name: "Metrics", package: "swift-metrics"),
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
@@ -50,6 +52,7 @@ let package = Package(
         ]),
         .target(name: "SotoTestUtils", dependencies: [
             .byName(name: "SotoCore"),
+            .product(name: "BaggageContext", package: "swift-context"),
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
             .product(name: "NIOFoundationCompat", package: "swift-nio"),

--- a/Sources/SotoCore/AWSClient+Paginate.swift
+++ b/Sources/SotoCore/AWSClient+Paginate.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BaggageContext
 import Logging
 import NIO
 
@@ -40,9 +41,9 @@ extension AWSClient {
     public func paginate<Input: AWSPaginateToken, Output: AWSShape, Result>(
         input: Input,
         initialValue: Result,
-        command: @escaping (Input, Logger, EventLoop?) -> EventLoopFuture<Output>,
+        command: @escaping (Input, BaggageContext, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
-        logger: Logger = AWSClient.loggingDisabled,
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         onPage: @escaping (Result, Output, EventLoop) -> EventLoopFuture<(Bool, Result)>
     ) -> EventLoopFuture<Result> {
@@ -50,7 +51,7 @@ extension AWSClient {
         let promise = eventLoop.makePromise(of: Result.self)
 
         func paginatePart(input: Input, currentValue: Result) {
-            let responseFuture = command(input, logger, eventLoop)
+            let responseFuture = command(input, context, eventLoop)
                 .flatMap { response in
                     return onPage(currentValue, response, eventLoop)
                         .map { continuePaginate, result -> Void in
@@ -85,13 +86,13 @@ extension AWSClient {
     ///   - onPage: closure called with each block of entries. Returns boolean indicating whether we should continue.
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
-        command: @escaping (Input, Logger, EventLoop?) -> EventLoopFuture<Output>,
+        command: @escaping (Input, BaggageContext, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
-        logger: Logger = AWSClient.loggingDisabled,
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
-        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, logger: logger, on: eventLoop) { _, output, eventLoop in
+        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, context: context, on: eventLoop) { _, output, eventLoop in
             return onPage(output, eventLoop).map { rt in (rt, ()) }
         }
     }
@@ -114,10 +115,10 @@ extension AWSClient {
     public func paginate<Input: AWSPaginateToken, Output: AWSShape, Result>(
         input: Input,
         initialValue: Result,
-        command: @escaping (Input, Logger, EventLoop?) -> EventLoopFuture<Output>,
+        command: @escaping (Input, BaggageContext, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool>,
-        logger: Logger = AWSClient.loggingDisabled,
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         onPage: @escaping (Result, Output, EventLoop) -> EventLoopFuture<(Bool, Result)>
     ) -> EventLoopFuture<Result> {
@@ -125,7 +126,7 @@ extension AWSClient {
         let promise = eventLoop.makePromise(of: Result.self)
 
         func paginatePart(input: Input, currentValue: Result) {
-            let responseFuture = command(input, logger, eventLoop)
+            let responseFuture = command(input, context, eventLoop)
                 .flatMap { response in
                     return onPage(currentValue, response, eventLoop)
                         .map { continuePaginate, result -> Void in
@@ -162,14 +163,14 @@ extension AWSClient {
     ///   - onPage: closure called with each block of entries. Returns boolean indicating whether we should continue.
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
-        command: @escaping (Input, Logger, EventLoop?) -> EventLoopFuture<Output>,
+        command: @escaping (Input, BaggageContext, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool>,
-        logger: Logger = AWSClient.loggingDisabled,
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
-        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, logger: logger, on: eventLoop) { _, output, eventLoop in
+        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, context: context, on: eventLoop) { _, output, eventLoop in
             return onPage(output, eventLoop).map { rt in (rt, ()) }
         }
     }
@@ -192,10 +193,10 @@ extension AWSClient {
     public func paginate<Input: AWSPaginateToken, Output: AWSShape, Result>(
         input: Input,
         initialValue: Result,
-        command: @escaping (Input, Logger, EventLoop?) -> EventLoopFuture<Output>,
+        command: @escaping (Input, BaggageContext, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool?>,
-        logger: Logger = AWSClient.loggingDisabled,
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         onPage: @escaping (Result, Output, EventLoop) -> EventLoopFuture<(Bool, Result)>
     ) -> EventLoopFuture<Result> {
@@ -203,7 +204,7 @@ extension AWSClient {
         let promise = eventLoop.makePromise(of: Result.self)
 
         func paginatePart(input: Input, currentValue: Result) {
-            let responseFuture = command(input, logger, eventLoop)
+            let responseFuture = command(input, context, eventLoop)
                 .flatMap { response in
                     return onPage(currentValue, response, eventLoop)
                         .map { continuePaginate, result -> Void in
@@ -240,14 +241,14 @@ extension AWSClient {
     ///   - onPage: closure called with each block of entries. Returns boolean indicating whether we should continue.
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
-        command: @escaping (Input, Logger, EventLoop?) -> EventLoopFuture<Output>,
+        command: @escaping (Input, BaggageContext, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool?>,
-        logger: Logger = AWSClient.loggingDisabled,
+        context: BaggageContext = AWSClient.defaultBaggageContext(),
         on eventLoop: EventLoop? = nil,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
-        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, logger: logger, on: eventLoop) { _, output, eventLoop in
+        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, context: context, on: eventLoop) { _, output, eventLoop in
             return onPage(output, eventLoop).map { rt in (rt, ()) }
         }
     }

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -471,8 +471,9 @@ extension AWSClient {
                 // send request to AWS and process result
                 return self.invoke(
                     with: config,
+                    eventLoop: eventLoop,
                     logger: context.logger,
-                    request: { execute(request, context, eventLoop) },
+                    request: { eventLoop in execute(request, context, eventLoop) },
                     processResponse: processResponse
                 )
             }

--- a/Sources/SotoCore/AWSService.swift
+++ b/Sources/SotoCore/AWSService.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BaggageContext
 import struct Foundation.URL
 import NIO
 
@@ -46,9 +47,9 @@ extension AWSService {
         httpMethod: HTTPMethod,
         headers: HTTPHeaders = HTTPHeaders(),
         expires: TimeAmount,
-        logger: Logger = AWSClient.loggingDisabled
+        context: BaggageContext = AWSClient.defaultBaggageContext()
     ) -> EventLoopFuture<URL> {
-        return self.client.signURL(url: url, httpMethod: httpMethod, headers: headers, expires: expires, serviceConfig: self.config, logger: logger)
+        return self.client.signURL(url: url, httpMethod: httpMethod, headers: headers, expires: expires, serviceConfig: self.config, context: context)
     }
 
     /// Return new version of Service with edited parameters

--- a/Sources/SotoCore/Baggage.swift
+++ b/Sources/SotoCore/Baggage.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2020 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Baggage
+
+private enum RequestIdKey: Baggage.Key {
+    typealias Value = Int
+    static var nameOverride: String? { "aws-request-id" }
+}
+
+private enum AWSServiceKey: Baggage.Key {
+    typealias Value = String
+    static var nameOverride: String? { "aws-service" }
+}
+
+private enum AWSOperationKey: Baggage.Key {
+    typealias Value = String
+    static var nameOverride: String? { "aws-operation" }
+}
+
+extension Baggage {
+    var awsService: String? {
+        get {
+            self[AWSServiceKey.self]
+        }
+        set {
+            self[AWSServiceKey.self] = newValue
+        }
+    }
+
+    var awsOperation: String? {
+        get {
+            self[AWSOperationKey.self]
+        }
+        set {
+            self[AWSOperationKey.self] = newValue
+        }
+    }
+
+    var awsRequestId: Int? {
+        get {
+            self[RequestIdKey.self]
+        }
+        set {
+            self[RequestIdKey.self] = newValue
+        }
+    }
+}

--- a/Sources/SotoCore/Credential/MetaDataCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/MetaDataCredentialProvider.swift
@@ -20,6 +20,7 @@ import struct Foundation.TimeInterval
 import struct Foundation.TimeZone
 import struct Foundation.URL
 
+import BaggageContext
 import Logging
 import NIO
 import NIOConcurrencyHelpers
@@ -119,7 +120,12 @@ struct ECSMetaDataClient: MetaDataClient {
 
     private func request(url: String, timeout: TimeInterval, on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<AWSHTTPResponse> {
         let request = AWSHTTPRequest(url: URL(string: url)!, method: .GET, headers: [:], body: .empty)
-        return httpClient.execute(request: request, timeout: TimeAmount.seconds(2), on: eventLoop, logger: logger)
+        return httpClient.execute(
+            request: request,
+            timeout: TimeAmount.seconds(2),
+            on: eventLoop,
+            context: DefaultContext.TODO(logger: logger, "Replace with context passed to credential provider when implemented")
+        )
     }
 }
 
@@ -258,6 +264,11 @@ struct InstanceMetaDataClient: MetaDataClient {
         logger: Logger
     ) -> EventLoopFuture<AWSHTTPResponse> {
         let request = AWSHTTPRequest(url: url, method: method, headers: headers, body: .empty)
-        return httpClient.execute(request: request, timeout: timeout, on: eventLoop, logger: logger)
+        return httpClient.execute(
+            request: request,
+            timeout: timeout,
+            on: eventLoop,
+            context: DefaultContext.TODO(logger: logger, "Replace with context passed to credential provider when implemented")
+        )
     }
 }

--- a/Sources/SotoCore/Exports.swift
+++ b/Sources/SotoCore/Exports.swift
@@ -15,8 +15,6 @@
 @_exported import protocol SotoSignerV4.Credential
 @_exported import struct SotoSignerV4.StaticCredential
 
-@_exported import struct Logging.Logger
-
 @_exported import struct NIO.ByteBuffer
 @_exported import struct NIO.ByteBufferAllocator
 @_exported import protocol NIO.EventLoop

--- a/Sources/SotoCore/HTTP/AWSHTTPClient.swift
+++ b/Sources/SotoCore/HTTP/AWSHTTPClient.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BaggageContext
 import Foundation
 import Logging
 import NIO
@@ -44,10 +45,10 @@ public protocol AWSHTTPClient {
     typealias ResponseStream = (ByteBuffer, EventLoop) -> EventLoopFuture<Void>
 
     /// Execute HTTP request and return a future holding a HTTP Response
-    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<AWSHTTPResponse>
+    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: BaggageContext) -> EventLoopFuture<AWSHTTPResponse>
 
     /// Execute an HTTP request with a streamed response
-    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse>
+    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: BaggageContext, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse>
 
     /// This should be called before an HTTP Client can be de-initialised
     func shutdown(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void)
@@ -58,7 +59,7 @@ public protocol AWSHTTPClient {
 
 extension AWSHTTPClient {
     /// Execute an HTTP request with a streamed response
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: BaggageContext, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
         preconditionFailure("\(type(of: self)) does not support response streaming")
     }
 }

--- a/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient
+import BaggageContext
 import Logging
 import NIO
 import NIOHTTP1
@@ -25,7 +26,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
     ///   - timeout: If execution is idle for longer than timeout then throw error
     ///   - eventLoop: eventLoop to run request on
     /// - Returns: EventLoopFuture that will be fulfilled with request response
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: BaggageContext) -> EventLoopFuture<AWSHTTPResponse> {
         let requestBody: AsyncHTTPClient.HTTPClient.Body?
         var requestHeaders = request.headers
 
@@ -51,14 +52,14 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
                 request: asyncRequest,
                 eventLoop: .delegate(on: eventLoop),
                 deadline: .now() + timeout,
-                logger: logger
+                logger: context.logger
             ).map { $0 }
         } catch {
             return eventLoopGroup.next().makeFailedFuture(error)
         }
     }
 
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
+    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, context: BaggageContext, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
         let requestBody: AsyncHTTPClient.HTTPClient.Body?
         if case .byteBuffer(let body) = request.body.payload {
             requestBody = .byteBuffer(body)
@@ -78,7 +79,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
                 delegate: delegate,
                 eventLoop: .delegate(on: eventLoop),
                 deadline: .now() + timeout,
-                logger: logger
+                logger: context.logger
             ).futureResult
                 // temporarily wait on delegate response finishing while AHC does not do this for us. See https://github.com/swift-server/async-http-client/issues/274
                 .flatMap { response in

--- a/Sources/SotoTestUtils/TestUtils.swift
+++ b/Sources/SotoTestUtils/TestUtils.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BaggageContext
 import Foundation
 import Logging
 import SotoCore
@@ -112,5 +113,9 @@ public struct TestEnvironment {
             }
         }
         return AWSClient.loggingDisabled
+    }()
+    
+    public static var context: BaggageContext = {
+        DefaultContext.topLevel(logger: logger)
     }()
 }

--- a/Sources/SotoTestUtils/TestUtils.swift
+++ b/Sources/SotoTestUtils/TestUtils.swift
@@ -114,7 +114,7 @@ public struct TestEnvironment {
         }
         return AWSClient.loggingDisabled
     }()
-    
+
     public static var context: BaggageContext = {
         DefaultContext.topLevel(logger: logger)
     }()

--- a/Tests/SotoCoreTests/AWSClientTests.swift
+++ b/Tests/SotoCoreTests/AWSClientTests.swift
@@ -109,7 +109,7 @@ class AWSClientTests: XCTestCase {
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
         }
-        let response: EventLoopFuture<AWSTestServer.HTTPBinResponse> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+        let response: EventLoopFuture<AWSTestServer.HTTPBinResponse> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, context: TestEnvironment.context)
 
         XCTAssertNoThrow(try awsServer.httpBin())
         var httpBinResponse: AWSTestServer.HTTPBinResponse?
@@ -133,7 +133,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try awsServer.stop())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, context: TestEnvironment.context)
 
             try awsServer.processRaw { _ in
                 let response = AWSTestServer.Response(httpStatus: .ok, headers: [:], body: nil)
@@ -165,7 +165,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try awsServer.stop())
             }
             let input = Input(e: .second, i: [1, 2, 4, 8])
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, context: TestEnvironment.context)
 
             try awsServer.processRaw { request in
                 let receivedInput = try JSONDecoder().decode(Input.self, from: request.body)
@@ -200,7 +200,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try awsServer.stop())
             }
-            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response: EventLoopFuture<Output> = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, context: TestEnvironment.context)
 
             try awsServer.processRaw { _ in
                 let output = Output(s: "TestOutputString", i: 547)
@@ -237,7 +237,7 @@ class AWSClientTests: XCTestCase {
             return eventLoop.makeSucceededFuture(.byteBuffer(buffer))
         }
         let input = Input(payload: payload)
-        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, context: TestEnvironment.context)
 
         try server.processRaw { request in
             let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
@@ -310,7 +310,7 @@ class AWSClientTests: XCTestCase {
                 return eventLoop.makeSucceededFuture(.byteBuffer(buffer))
             }
             let input = Input(payload: payload)
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, context: TestEnvironment.context)
             try response.wait()
         } catch let error as HTTPClientError where error == .bodyLengthMismatch {
         } catch {
@@ -355,7 +355,7 @@ class AWSClientTests: XCTestCase {
             }
 
             let input = Input(payload: .fileHandle(fileHandle, size: bufferSize, fileIO: fileIO) { size in print(size) })
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, context: TestEnvironment.context)
 
             try awsServer.processRaw { request in
                 XCTAssertNil(request.headers["transfer-encoding"])
@@ -407,7 +407,7 @@ class AWSClientTests: XCTestCase {
                 }
             }
             let input = Input(payload: payload)
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, context: TestEnvironment.context)
 
             try awsServer.processRaw { request in
                 let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
@@ -436,7 +436,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, context: TestEnvironment.context)
 
             try awsServer.processRaw { _ in
                 let response = AWSTestServer.Response(httpStatus: .temporaryRedirect, headers: ["Location": awsServer.address], body: nil)
@@ -472,7 +472,7 @@ class AWSClientTests: XCTestCase {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
             }
-            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+            let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, context: TestEnvironment.context)
 
             var count = 0
             try awsServer.processRaw { _ in
@@ -516,7 +516,7 @@ class AWSClientTests: XCTestCase {
                 path: "/",
                 httpMethod: .POST,
                 serviceConfig: config,
-                logger: TestEnvironment.logger
+                context: TestEnvironment.context
             )
 
             var count = 0
@@ -572,7 +572,7 @@ class AWSClientTests: XCTestCase {
                 path: "/",
                 httpMethod: .POST,
                 serviceConfig: config,
-                logger: TestEnvironment.logger
+                context: TestEnvironment.context
             )
 
             try response.wait()
@@ -602,7 +602,7 @@ class AWSClientTests: XCTestCase {
                 path: "/",
                 httpMethod: .POST,
                 serviceConfig: config,
-                logger: TestEnvironment.logger
+                context: TestEnvironment.context
             )
 
             try awsServer.processRaw { _ in
@@ -638,7 +638,7 @@ class AWSClientTests: XCTestCase {
                 path: "/",
                 httpMethod: .POST,
                 serviceConfig: config,
-                logger: TestEnvironment.logger,
+                context: TestEnvironment.context,
                 on: eventLoop
             )
 
@@ -680,7 +680,7 @@ class AWSClientTests: XCTestCase {
                 httpMethod: .GET,
                 serviceConfig: config,
                 input: Input(),
-                logger: TestEnvironment.logger
+                context: TestEnvironment.context
             ) { (payload: ByteBuffer, eventLoop: EventLoop) in
                 let payloadSize = payload.readableBytes
                 let slice = Data(data[count..<(count + payloadSize)])
@@ -733,7 +733,7 @@ class AWSClientTests: XCTestCase {
             httpMethod: .GET,
             serviceConfig: config,
             input: Input(),
-            logger: TestEnvironment.logger
+            context: TestEnvironment.context
         ) { (_: ByteBuffer, eventLoop: EventLoop) in
             lock.withLock { count += 1 }
             return eventLoop.scheduleTask(in: .milliseconds(200)) {
@@ -769,7 +769,7 @@ class AWSClientTests: XCTestCase {
             XCTAssertNoThrow(try awsServer.stop())
         }
 
-        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, logger: TestEnvironment.logger)
+        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, context: TestEnvironment.context)
 
         XCTAssertNoThrow(try awsServer.processRaw { request in
             XCTAssertEqual(request.uri, "/test")

--- a/Tests/SotoCoreTests/PaginateTests.swift
+++ b/Tests/SotoCoreTests/PaginateTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient
+import BaggageContext
 import NIO
 @testable import SotoCore
 import SotoTestUtils
@@ -66,14 +67,14 @@ class PaginateTests: XCTestCase {
         let outputToken: Int?
     }
 
-    func counter(_ input: CounterInput, logger: Logger, on eventLoop: EventLoop?) -> EventLoopFuture<CounterOutput> {
+    func counter(_ input: CounterInput, context: BaggageContext, on eventLoop: EventLoop?) -> EventLoopFuture<CounterOutput> {
         return self.client.execute(
             operation: "TestOperation",
             path: "/",
             httpMethod: .POST,
             serviceConfig: self.config,
             input: input,
-            logger: logger,
+            context: context,
             on: eventLoop
         )
     }
@@ -83,7 +84,7 @@ class PaginateTests: XCTestCase {
             input: input,
             command: self.counter,
             tokenKey: \CounterOutput.outputToken,
-            logger: TestEnvironment.logger,
+            context: TestEnvironment.context,
             onPage: onPage
         )
     }
@@ -152,14 +153,14 @@ class PaginateTests: XCTestCase {
         let moreResults: Bool
     }
 
-    func stringList(_ input: StringListInput, logger: Logger, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StringListOutput> {
+    func stringList(_ input: StringListInput, context: BaggageContext, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StringListOutput> {
         return self.client.execute(
             operation: "TestOperation",
             path: "/",
             httpMethod: .POST,
             serviceConfig: self.config,
             input: input,
-            logger: logger,
+            context: context,
             on: eventLoop
         )
     }
@@ -170,20 +171,20 @@ class PaginateTests: XCTestCase {
             command: self.stringList,
             tokenKey: \StringListOutput.outputToken,
             moreResultsKey: \StringListOutput.moreResults,
-            logger: TestEnvironment.logger,
+            context: TestEnvironment.context,
             on: eventLoop,
             onPage: onPage
         )
     }
 
-    func stringList2(_ input: StringListInput, logger: Logger, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StringList2Output> {
+    func stringList2(_ input: StringListInput, context: BaggageContext, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StringList2Output> {
         return self.client.execute(
             operation: "TestOperation",
             path: "/",
             httpMethod: .POST,
             serviceConfig: self.config,
             input: input,
-            logger: logger,
+            context: context,
             on: eventLoop
         )
     }
@@ -195,7 +196,7 @@ class PaginateTests: XCTestCase {
             command: self.stringList2,
             tokenKey: \StringList2Output.outputToken,
             moreResultsKey: \StringList2Output.moreResults,
-            logger: TestEnvironment.logger,
+            context: TestEnvironment.context,
             on: eventLoop,
             onPage: onPage
         )

--- a/Tests/SotoCoreTests/PayloadTests.swift
+++ b/Tests/SotoCoreTests/PayloadTests.swift
@@ -40,7 +40,7 @@ class PayloadTests: XCTestCase {
                 httpMethod: .POST,
                 serviceConfig: config,
                 input: input,
-                logger: TestEnvironment.logger
+                context: TestEnvironment.context
             )
 
             try awsServer.processRaw { request in
@@ -87,7 +87,7 @@ class PayloadTests: XCTestCase {
                 path: "/",
                 httpMethod: .POST,
                 serviceConfig: config,
-                logger: TestEnvironment.logger
+                context: TestEnvironment.context
             )
 
             try awsServer.processRaw { _ in


### PR DESCRIPTION
This is version 2 of placing the logger parameters with a baggage context. Merging in latest changes was too much of a pain. Original PR can be found here #372 

Changes required to the public API of Soto for integrating with the swift tracing code. It is not intended that I add instrumentation code here. All we are doing is passing in the Context

The PR has a fairly limited scope in that it only covers the interface functions of AWSClient and passes the Context down to the HTTP client. Although we can't actually pass it to AsyncHTTPClient.HTTPClient yet.
