### PR TITLE
Logger Eventloop parameter ordering

### DIFF
--- a/Sources/SotoCore/AWSClient+Paginate.swift
+++ b/Sources/SotoCore/AWSClient+Paginate.swift
@@ -42,8 +42,8 @@ extension AWSClient {
         initialValue: Result,
         command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
-        on eventLoop: EventLoop? = nil,
         logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil,
         onPage: @escaping (Result, Output, EventLoop) -> EventLoopFuture<(Bool, Result)>
     ) -> EventLoopFuture<Result> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
@@ -87,11 +87,11 @@ extension AWSClient {
         input: Input,
         command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
-        on eventLoop: EventLoop? = nil,
         logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
-        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, on: eventLoop, logger: logger) { _, output, eventLoop in
+        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, logger: logger, on: eventLoop) { _, output, eventLoop in
             return onPage(output, eventLoop).map { rt in (rt, ()) }
         }
     }
@@ -117,8 +117,8 @@ extension AWSClient {
         command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool>,
-        on eventLoop: EventLoop? = nil,
         logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil,
         onPage: @escaping (Result, Output, EventLoop) -> EventLoopFuture<(Bool, Result)>
     ) -> EventLoopFuture<Result> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
@@ -165,11 +165,11 @@ extension AWSClient {
         command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool>,
-        on eventLoop: EventLoop? = nil,
         logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
-        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, on: eventLoop, logger: logger) { _, output, eventLoop in
+        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, logger: logger, on: eventLoop) { _, output, eventLoop in
             return onPage(output, eventLoop).map { rt in (rt, ()) }
         }
     }
@@ -195,8 +195,8 @@ extension AWSClient {
         command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool?>,
-        on eventLoop: EventLoop? = nil,
         logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil,
         onPage: @escaping (Result, Output, EventLoop) -> EventLoopFuture<(Bool, Result)>
     ) -> EventLoopFuture<Result> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
@@ -243,11 +243,11 @@ extension AWSClient {
         command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool?>,
-        on eventLoop: EventLoop? = nil,
         logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil,
         onPage: @escaping (Output, EventLoop) -> EventLoopFuture<Bool>
     ) -> EventLoopFuture<Void> {
-        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, on: eventLoop, logger: logger) { _, output, eventLoop in
+        self.paginate(input: input, initialValue: (), command: command, tokenKey: tokenKey, moreResultsKey: moreResultsKey, logger: logger, on: eventLoop) { _, output, eventLoop in
             return onPage(output, eventLoop).map { rt in (rt, ()) }
         }
     }

--- a/Sources/SotoCore/AWSClient+Paginate.swift
+++ b/Sources/SotoCore/AWSClient+Paginate.swift
@@ -40,7 +40,7 @@ extension AWSClient {
     public func paginate<Input: AWSPaginateToken, Output: AWSShape, Result>(
         input: Input,
         initialValue: Result,
-        command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
+        command: @escaping (Input, Logger, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         logger: Logger = AWSClient.loggingDisabled,
         on eventLoop: EventLoop? = nil,
@@ -50,7 +50,7 @@ extension AWSClient {
         let promise = eventLoop.makePromise(of: Result.self)
 
         func paginatePart(input: Input, currentValue: Result) {
-            let responseFuture = command(input, eventLoop, logger)
+            let responseFuture = command(input, logger, eventLoop)
                 .flatMap { response in
                     return onPage(currentValue, response, eventLoop)
                         .map { continuePaginate, result -> Void in
@@ -85,7 +85,7 @@ extension AWSClient {
     ///   - onPage: closure called with each block of entries. Returns boolean indicating whether we should continue.
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
-        command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
+        command: @escaping (Input, Logger, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         logger: Logger = AWSClient.loggingDisabled,
         on eventLoop: EventLoop? = nil,
@@ -114,7 +114,7 @@ extension AWSClient {
     public func paginate<Input: AWSPaginateToken, Output: AWSShape, Result>(
         input: Input,
         initialValue: Result,
-        command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
+        command: @escaping (Input, Logger, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool>,
         logger: Logger = AWSClient.loggingDisabled,
@@ -125,7 +125,7 @@ extension AWSClient {
         let promise = eventLoop.makePromise(of: Result.self)
 
         func paginatePart(input: Input, currentValue: Result) {
-            let responseFuture = command(input, eventLoop, logger)
+            let responseFuture = command(input, logger, eventLoop)
                 .flatMap { response in
                     return onPage(currentValue, response, eventLoop)
                         .map { continuePaginate, result -> Void in
@@ -162,7 +162,7 @@ extension AWSClient {
     ///   - onPage: closure called with each block of entries. Returns boolean indicating whether we should continue.
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
-        command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
+        command: @escaping (Input, Logger, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool>,
         logger: Logger = AWSClient.loggingDisabled,
@@ -192,7 +192,7 @@ extension AWSClient {
     public func paginate<Input: AWSPaginateToken, Output: AWSShape, Result>(
         input: Input,
         initialValue: Result,
-        command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
+        command: @escaping (Input, Logger, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool?>,
         logger: Logger = AWSClient.loggingDisabled,
@@ -203,7 +203,7 @@ extension AWSClient {
         let promise = eventLoop.makePromise(of: Result.self)
 
         func paginatePart(input: Input, currentValue: Result) {
-            let responseFuture = command(input, eventLoop, logger)
+            let responseFuture = command(input, logger, eventLoop)
                 .flatMap { response in
                     return onPage(currentValue, response, eventLoop)
                         .map { continuePaginate, result -> Void in
@@ -240,7 +240,7 @@ extension AWSClient {
     ///   - onPage: closure called with each block of entries. Returns boolean indicating whether we should continue.
     public func paginate<Input: AWSPaginateToken, Output: AWSShape>(
         input: Input,
-        command: @escaping (Input, EventLoop?, Logger) -> EventLoopFuture<Output>,
+        command: @escaping (Input, Logger, EventLoop?) -> EventLoopFuture<Output>,
         tokenKey: KeyPath<Output, Input.Token?>,
         moreResultsKey: KeyPath<Output, Bool?>,
         logger: Logger = AWSClient.loggingDisabled,

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -243,8 +243,8 @@ extension AWSClient {
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
         input: Input,
-        on eventLoop: EventLoop? = nil,
-        logger: Logger = AWSClient.loggingDisabled
+        logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Void> {
         return execute(
             operation: operationName,
@@ -283,8 +283,8 @@ extension AWSClient {
         path: String,
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
-        on eventLoop: EventLoop? = nil,
-        logger: Logger = AWSClient.loggingDisabled
+        logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Void> {
         return execute(
             operation: operationName,
@@ -322,8 +322,8 @@ extension AWSClient {
         path: String,
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
-        on eventLoop: EventLoop? = nil,
-        logger: Logger = AWSClient.loggingDisabled
+        logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Output> {
         return execute(
             operation: operationName,
@@ -363,8 +363,8 @@ extension AWSClient {
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
         input: Input,
-        on eventLoop: EventLoop? = nil,
-        logger: Logger = AWSClient.loggingDisabled
+        logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Output> {
         return execute(
             operation: operationName,
@@ -405,8 +405,8 @@ extension AWSClient {
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
         input: Input,
-        on eventLoop: EventLoop? = nil,
         logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil,
         stream: @escaping AWSHTTPClient.ResponseStream
     ) -> EventLoopFuture<Output> {
         return execute(

--- a/Tests/SotoCoreTests/AWSClientTests.swift
+++ b/Tests/SotoCoreTests/AWSClientTests.swift
@@ -638,8 +638,8 @@ class AWSClientTests: XCTestCase {
                 path: "/",
                 httpMethod: .POST,
                 serviceConfig: config,
-                on: eventLoop,
-                logger: TestEnvironment.logger
+                logger: TestEnvironment.logger,
+                on: eventLoop
             )
 
             try awsServer.processRaw { _ in

--- a/Tests/SotoCoreTests/PaginateTests.swift
+++ b/Tests/SotoCoreTests/PaginateTests.swift
@@ -66,7 +66,7 @@ class PaginateTests: XCTestCase {
         let outputToken: Int?
     }
 
-    func counter(_ input: CounterInput, on eventLoop: EventLoop?, logger: Logger) -> EventLoopFuture<CounterOutput> {
+    func counter(_ input: CounterInput, logger: Logger, on eventLoop: EventLoop?) -> EventLoopFuture<CounterOutput> {
         return self.client.execute(
             operation: "TestOperation",
             path: "/",
@@ -152,7 +152,7 @@ class PaginateTests: XCTestCase {
         let moreResults: Bool
     }
 
-    func stringList(_ input: StringListInput, on eventLoop: EventLoop? = nil, logger: Logger) -> EventLoopFuture<StringListOutput> {
+    func stringList(_ input: StringListInput, logger: Logger, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StringListOutput> {
         return self.client.execute(
             operation: "TestOperation",
             path: "/",
@@ -176,7 +176,7 @@ class PaginateTests: XCTestCase {
         )
     }
 
-    func stringList2(_ input: StringListInput, on eventLoop: EventLoop? = nil, logger: Logger) -> EventLoopFuture<StringList2Output> {
+    func stringList2(_ input: StringListInput, logger: Logger, on eventLoop: EventLoop? = nil) -> EventLoopFuture<StringList2Output> {
         return self.client.execute(
             operation: "TestOperation",
             path: "/",

--- a/Tests/SotoCoreTests/PaginateTests.swift
+++ b/Tests/SotoCoreTests/PaginateTests.swift
@@ -73,8 +73,8 @@ class PaginateTests: XCTestCase {
             httpMethod: .POST,
             serviceConfig: self.config,
             input: input,
-            on: eventLoop,
-            logger: logger
+            logger: logger,
+            on: eventLoop
         )
     }
 
@@ -159,8 +159,8 @@ class PaginateTests: XCTestCase {
             httpMethod: .POST,
             serviceConfig: self.config,
             input: input,
-            on: eventLoop,
-            logger: logger
+            logger: logger,
+            on: eventLoop
         )
     }
 
@@ -170,8 +170,8 @@ class PaginateTests: XCTestCase {
             command: self.stringList,
             tokenKey: \StringListOutput.outputToken,
             moreResultsKey: \StringListOutput.moreResults,
-            on: eventLoop,
             logger: TestEnvironment.logger,
+            on: eventLoop,
             onPage: onPage
         )
     }
@@ -183,8 +183,8 @@ class PaginateTests: XCTestCase {
             httpMethod: .POST,
             serviceConfig: self.config,
             input: input,
-            on: eventLoop,
-            logger: logger
+            logger: logger,
+            on: eventLoop
         )
     }
 
@@ -195,8 +195,8 @@ class PaginateTests: XCTestCase {
             command: self.stringList2,
             tokenKey: \StringList2Output.outputToken,
             moreResultsKey: \StringList2Output.moreResults,
-            on: eventLoop,
             logger: TestEnvironment.logger,
+            on: eventLoop,
             onPage: onPage
         )
     }


### PR DESCRIPTION
Re-order Logger and EventLoop parameters in public functions of AWSClient so it is easier to replace Logger with BaggageContext at a later date