### PR TITLE
Fix issue with S3 streamer

### DIFF
--- a/Sources/SotoCore/HTTP/S3StreamReader.swift
+++ b/Sources/SotoCore/HTTP/S3StreamReader.swift
@@ -152,26 +152,6 @@ class S3ChunkedStreamReader: StreamReader {
         }
     }
 
-    /*func flushChunks(on eventLoop: EventLoop) -> EventLoopFuture<[ByteBuffer]> {
-        var byteBuffers: [ByteBuffer] = []
-        var promise: EventLoopPromise<[ByteBuffer]> = eventLoop.makePromise()
-        
-        func _flushChunks(on eventLoop: EventLoop) -> EventLoopFuture<[ByteBuffer]> {
-            self.fillWorkingBuffer(on: eventLoop).map { buffer in
-                if buffer.readableBytes == 0 {
-                    promise.succeed(byteBuffers)
-                }
-                // sign header etc
-                self.signingData = self.signer.signChunk(body: .byteBuffer(buffer), signingData: self.signingData)
-                let header = "\(String(buffer.readableBytes, radix: 16));chunk-signature=\(self.signingData.signature)\r\n"
-                self.headerBuffer.clear()
-                self.headerBuffer.writeString(header)
-
-                byteBuffers += [self.headerBuffer, buffer, self.tailBuffer]
-            }//.cascadeFailure(to: promise)
-        }
-        return promise.futureResult
-    }*/
     /// Calculate content size for aws chunked data.
     var contentSize: Int? {
         let size = self.size!

--- a/Tests/SotoCoreTests/AWSClientTests.swift
+++ b/Tests/SotoCoreTests/AWSClientTests.swift
@@ -277,11 +277,14 @@ class AWSClientTests: XCTestCase {
         }
 
         XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: 16 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 192 * 1024, blockSize: 128 * 1024))
         XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 81 * 1024, blockSize: 16 * 1024))
         XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: S3ChunkedStreamReader.bufferSize))
         XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 130 * 1024, blockSize: S3ChunkedStreamReader.bufferSize))
         XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: 17 * 1024))
-        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 18 * 1024, blockSize: 47 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 68 * 1024, blockSize: 67 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 65537, blockSize: 65537))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 65552, blockSize: 65552))
     }
 
     func testRequestStreamingTooMuchData() {


### PR DESCRIPTION
Stop streamer sending buffers that are too large when it is fed bytebuffers greater than the chunk buffer size (64KB)