### PR TITLE
Allow loading credentials from profile and default

### DIFF
--- a/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
@@ -99,15 +99,18 @@ struct AWSConfigFileCredentialProvider: CredentialProvider {
             throw ConfigFileError.missingProfile(profile)
         }
 
-        guard let accessKeyId = config["aws_access_key_id"] else {
+        // Profile credentials can "borrow" values from the 'default' profile when they have not been overriden
+        let defaultConfig = parser.sections["default"]
+
+        guard let accessKeyId = config["aws_access_key_id"] ?? defaultConfig?["aws_access_key_id"] else {
             throw ConfigFileError.missingAccessKeyId
         }
 
-        guard let secretAccessKey = config["aws_secret_access_key"] else {
+        guard let secretAccessKey = config["aws_secret_access_key"] ?? defaultConfig?["aws_secret_access_key"] else {
             throw ConfigFileError.missingSecretAccessKey
         }
 
-        let sessionToken = config["aws_session_token"]
+        let sessionToken = config["aws_session_token"] ?? defaultConfig?["aws_session_token"]
 
         return StaticCredential(accessKeyId: accessKeyId, secretAccessKey: secretAccessKey, sessionToken: sessionToken)
     }

--- a/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
@@ -229,6 +229,145 @@ class ConfigFileCredentialProviderTests: XCTestCase {
         XCTAssertEqual(credential?.secretAccessKey, "TESTPROFILE-AWSSECRETACCESSKEY")
     }
 
+    func testAWSProfileConfigFileWithDefaultSessionToken() {
+        let credentials = """
+        [default]
+        aws_session_token = TESTDEFAULT-SESSIONTOKEN
+        aws_access_key_id = TESTDEFAULT-AWSACCESSKEYID
+        aws_secret_access_key = TESTDEFAULT-AWSSECRETACCESSKEY
+
+        [test-profile]
+        aws_access_key_id = TESTPROFILE-AWSACCESSKEYID
+        aws_secret_access_key = TESTPROFILE-AWSSECRETACCESSKEY
+        """
+        Environment.set("test-profile", for: "AWS_PROFILE")
+        defer { Environment.unset(name: "AWS_PROFILE") }
+
+        let filename = "credentials"
+        let filenameURL = URL(fileURLWithPath: filename)
+        XCTAssertNoThrow(try Data(credentials.utf8).write(to: filenameURL))
+        defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: filenameURL)) }
+
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let eventLoop = eventLoopGroup.next()
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoop))
+        defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
+        let factory = CredentialProviderFactory.configFile(credentialsFilePath: filenameURL.path)
+
+        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger))
+
+        var credential: Credential?
+        XCTAssertNoThrow(credential = try provider.getCredential(on: eventLoop, logger: TestEnvironment.logger).wait())
+        XCTAssertEqual(credential?.sessionToken, "TESTDEFAULT-SESSIONTOKEN")
+        XCTAssertEqual(credential?.accessKeyId, "TESTPROFILE-AWSACCESSKEYID")
+        XCTAssertEqual(credential?.secretAccessKey, "TESTPROFILE-AWSSECRETACCESSKEY")
+    }
+
+    func testAWSProfileConfigFileWithDefaultAccessKey() {
+        let credentials = """
+        [default]
+        aws_session_token = TESTDEFAULT-SESSIONTOKEN
+        aws_access_key_id = TESTDEFAULT-AWSACCESSKEYID
+        aws_secret_access_key = TESTDEFAULT-AWSSECRETACCESSKEY
+
+        [test-profile]
+        aws_session_token = TESTPROFILE-SESSIONTOKEN
+        aws_secret_access_key = TESTPROFILE-AWSSECRETACCESSKEY
+        """
+        Environment.set("test-profile", for: "AWS_PROFILE")
+        defer { Environment.unset(name: "AWS_PROFILE") }
+
+        let filename = "credentials"
+        let filenameURL = URL(fileURLWithPath: filename)
+        XCTAssertNoThrow(try Data(credentials.utf8).write(to: filenameURL))
+        defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: filenameURL)) }
+
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let eventLoop = eventLoopGroup.next()
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoop))
+        defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
+        let factory = CredentialProviderFactory.configFile(credentialsFilePath: filenameURL.path)
+
+        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger))
+
+        var credential: Credential?
+        XCTAssertNoThrow(credential = try provider.getCredential(on: eventLoop, logger: TestEnvironment.logger).wait())
+        XCTAssertEqual(credential?.sessionToken, "TESTPROFILE-SESSIONTOKEN")
+        XCTAssertEqual(credential?.accessKeyId, "TESTDEFAULT-AWSACCESSKEYID")
+        XCTAssertEqual(credential?.secretAccessKey, "TESTPROFILE-AWSSECRETACCESSKEY")
+    }
+
+    func testAWSProfileConfigFileWithDefaultSecretKey() {
+        let credentials = """
+        [default]
+        aws_session_token = TESTDEFAULT-SESSIONTOKEN
+        aws_access_key_id = TESTDEFAULT-AWSACCESSKEYID
+        aws_secret_access_key = TESTDEFAULT-AWSSECRETACCESSKEY
+
+        [test-profile]
+        aws_session_token = TESTPROFILE-SESSIONTOKEN
+        aws_access_key_id = TESTPROFILE-AWSACCESSKEYID
+        """
+        Environment.set("test-profile", for: "AWS_PROFILE")
+        defer { Environment.unset(name: "AWS_PROFILE") }
+
+        let filename = "credentials"
+        let filenameURL = URL(fileURLWithPath: filename)
+        XCTAssertNoThrow(try Data(credentials.utf8).write(to: filenameURL))
+        defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: filenameURL)) }
+
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let eventLoop = eventLoopGroup.next()
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoop))
+        defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
+        let factory = CredentialProviderFactory.configFile(credentialsFilePath: filenameURL.path)
+
+        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger))
+
+        var credential: Credential?
+        XCTAssertNoThrow(credential = try provider.getCredential(on: eventLoop, logger: TestEnvironment.logger).wait())
+        XCTAssertEqual(credential?.sessionToken, "TESTPROFILE-SESSIONTOKEN")
+        XCTAssertEqual(credential?.accessKeyId, "TESTPROFILE-AWSACCESSKEYID")
+        XCTAssertEqual(credential?.secretAccessKey, "TESTDEFAULT-AWSSECRETACCESSKEY")
+    }
+
+    func testAWSProfileConfigFileWithAllDefault() {
+        let credentials = """
+        [default]
+        aws_session_token = TESTDEFAULT-SESSIONTOKEN
+        aws_access_key_id = TESTDEFAULT-AWSACCESSKEYID
+        aws_secret_access_key = TESTDEFAULT-AWSSECRETACCESSKEY
+
+        [test-profile]
+        foo = bar
+        """
+        Environment.set("test-profile", for: "AWS_PROFILE")
+        defer { Environment.unset(name: "AWS_PROFILE") }
+
+        let filename = "credentials"
+        let filenameURL = URL(fileURLWithPath: filename)
+        XCTAssertNoThrow(try Data(credentials.utf8).write(to: filenameURL))
+        defer { XCTAssertNoThrow(try FileManager.default.removeItem(at: filenameURL)) }
+
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let eventLoop = eventLoopGroup.next()
+        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
+        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoop))
+        defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
+        let factory = CredentialProviderFactory.configFile(credentialsFilePath: filenameURL.path)
+
+        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger))
+
+        var credential: Credential?
+        XCTAssertNoThrow(credential = try provider.getCredential(on: eventLoop, logger: TestEnvironment.logger).wait())
+        XCTAssertEqual(credential?.sessionToken, "TESTDEFAULT-SESSIONTOKEN")
+        XCTAssertEqual(credential?.accessKeyId, "TESTDEFAULT-AWSACCESSKEYID")
+        XCTAssertEqual(credential?.secretAccessKey, "TESTDEFAULT-AWSSECRETACCESSKEY")
+    }
+
     func testConfigFileNotAvailable() {
         let filename = "credentials_not_existing"
         let filenameURL = URL(fileURLWithPath: filename)


### PR DESCRIPTION
AWS credentials file allows for using values from the "default" profile when these have not been overridden by another profile. This is, a profile that does not have a property defined, will use the default value for it.

This update fixes the code that loads credentials when a given profile is specified.

Example credentials file:
```
[default]
aws_session_token = TESTDEFAULT-SESSIONTOKEN
aws_access_key_id = TESTDEFAULT-AWSACCESSKEYID
aws_secret_access_key = TESTDEFAULT-AWSSECRETACCESSKEY

[test-profile]
aws_access_key_id = TESTPROFILE-AWSACCESSKEYID
aws_secret_access_key = TESTPROFILE-AWSSECRETACCESSKEY
```

Whit this configuration file, when `test-profile` profile is used, the value for `aws_session_token` should be `TESTDEFAULT-SESSIONTOKEN`.

More examples have been added as unit tests, with full code coverage.