### PR TITLE
[CI] Use install-swift-tool instead of mint

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -13,9 +13,10 @@ jobs:
       uses: actions/checkout@v1
       with:
         fetch-depth: 1
-    - name: Install Dependencies
-      run: |
-        brew install mint
-        mint install nicklockwood/swiftformat@0.46.3
+    - name: Install SwiftFormat
+      uses: Cyberbeni/install-swift-tool@v2
+      with:
+        url: https://github.com/nicklockwood/SwiftFormat
+        branch: '0.46.3'
     - name: run script
       run: ./scripts/sanity.sh

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -4,10 +4,13 @@ on:
   pull_request:
     branches:
     - main
+  push:
+    branches:
+    - main
 
 jobs:
   sanity-check:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v1


### PR DESCRIPTION
install-swift-tool also builds tools from source, like mint but it includes caching and avoids the overhead of `brew install mint`

I believe that the current trigger means that it will generate a cache for every pull request. If we also add a trigger to run on pushes to the default branch then the pull requests could also load it from cache on the first run of every pull request. Source: https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache