### PR TITLE
Fixes for the V4 Signer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   ENABLE_TIMING_TESTS: "false"
-  AWS_LOG_LEVEL: "info"
+  AWS_LOG_LEVEL: "trace"
 
 jobs:
   macos:

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -464,6 +464,34 @@ extension AWSClient {
         }
     }
 
+    /// Generate signed headers
+    /// - parameters:
+    ///     - url : URL to sign
+    ///     - httpMethod: HTTP method to use (.GET, .PUT, .PUSH etc)
+    ///     - httpHeaders: Headers that are to be used with this URL.
+    ///     - body: Payload to sign as well. While it is unnecessary to provide the body for S3 other services may require it
+    ///     - serviceConfig: additional AWS service configuration used to sign the url
+    ///     - logger: Logger to output to
+    /// - returns:
+    ///     A set of signed headers that include the original headers supplied
+    public func signHeaders(
+        url: URL,
+        httpMethod: HTTPMethod,
+        headers: HTTPHeaders = HTTPHeaders(),
+        body: AWSPayload,
+        serviceConfig: AWSServiceConfig,
+        logger: Logger = AWSClient.loggingDisabled
+    ) -> EventLoopFuture<HTTPHeaders> {
+        let logger = logger.attachingRequestId(Self.globalRequestID.add(1), operation: "signURL", service: serviceConfig.service)
+        return createSigner(serviceConfig: serviceConfig, logger: logger).flatMapThrowing { signer in
+            guard let cleanURL = signer.processURL(url: url) else {
+                throw AWSClient.ClientError.invalidURL
+            }
+            let body: AWSSigner.BodyData? = body.asByteBuffer().map { .byteBuffer($0) }
+            return signer.signHeaders(url: cleanURL, method: httpMethod, headers: headers, body: body)
+        }
+    }
+
     func createSigner(serviceConfig: AWSServiceConfig, logger: Logger) -> EventLoopFuture<AWSSigner> {
         return credentialProvider.getCredential(on: eventLoopGroup.next(), logger: logger).map { credential in
             return AWSSigner(credentials: credential, name: serviceConfig.signingName, region: serviceConfig.region.rawValue)

--- a/Sources/SotoCore/AWSService.swift
+++ b/Sources/SotoCore/AWSService.swift
@@ -33,11 +33,11 @@ extension AWSService {
     /// The EventLoopGroup service is using
     public var eventLoopGroup: EventLoopGroup { return client.eventLoopGroup }
 
-    /// generate a signed URL
+    /// Generate a signed URL
     /// - parameters:
     ///     - url : URL to sign
     ///     - httpMethod: HTTP method to use (.GET, .PUT, .PUSH etc)
-    ///     - httpHeaders: Headers that are to be used with this URL. Be sure to include these headers when you used the returned URL
+    ///     - headers: Headers that are to be used with this URL. Be sure to include these headers when you used the returned URL
     ///     - expires: How long before the signed URL expires
     ///     - logger: Logger to output to
     /// - returns:
@@ -50,6 +50,25 @@ extension AWSService {
         logger: Logger = AWSClient.loggingDisabled
     ) -> EventLoopFuture<URL> {
         return self.client.signURL(url: url, httpMethod: httpMethod, headers: headers, expires: expires, serviceConfig: self.config, logger: logger)
+    }
+
+    /// Generate signed headers
+    /// - parameters:
+    ///     - url : URL to sign
+    ///     - httpMethod: HTTP method to use (.GET, .PUT, .PUSH etc)
+    ///     - headers: Headers that are to be used with this URL. Be sure to include these headers when you used the returned URL
+    ///     - body: body payload to sign as well. While it is unnecessary to provide the body for S3 other services require it
+    ///     - logger: Logger to output to
+    /// - returns:
+    ///     A series of signed headers including the original headers provided to the function
+    public func signHeaders(
+        url: URL,
+        httpMethod: HTTPMethod,
+        headers: HTTPHeaders = HTTPHeaders(),
+        body: AWSPayload = .empty,
+        logger: Logger = AWSClient.loggingDisabled
+    ) -> EventLoopFuture<HTTPHeaders> {
+        return self.client.signHeaders(url: url, httpMethod: httpMethod, headers: headers, body: body, serviceConfig: self.config, logger: logger)
     }
 
     /// Return new version of Service with edited parameters

--- a/Sources/SotoCore/Message/AWSRequest.swift
+++ b/Sources/SotoCore/Message/AWSRequest.swift
@@ -250,8 +250,14 @@ extension AWSRequest {
         // Also the signer doesn't percent encode the queries so they need to be encoded here
         if queryParams.count > 0 {
             let urlQueryString = queryParams
-                .sorted { $0.key < $1.key }
-                .map { "\($0.key)=\(Self.urlEncodeQueryParam("\($0.value)"))" }
+                .map { (key: $0.key, value: "\($0.value)")}
+                .sorted {
+                    // sort by key. if key are equal then sort by value
+                    if $0.key < $1.key { return true }
+                    if $0.key > $1.key { return false }
+                    return $0.value < $1.value
+                }
+                .map { "\($0.key)=\(Self.urlEncodeQueryParam($0.value))" }
                 .joined(separator: "&")
             urlComponents.percentEncodedQuery = urlQueryString
         }

--- a/Sources/SotoCore/Message/AWSRequest.swift
+++ b/Sources/SotoCore/Message/AWSRequest.swift
@@ -250,7 +250,7 @@ extension AWSRequest {
         // Also the signer doesn't percent encode the queries so they need to be encoded here
         if queryParams.count > 0 {
             let urlQueryString = queryParams
-                .map { (key: $0.key, value: "\($0.value)")}
+                .map { (key: $0.key, value: "\($0.value)") }
                 .sorted {
                     // sort by key. if key are equal then sort by value
                     if $0.key < $1.key { return true }

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -52,7 +52,7 @@ public struct AWSSigner {
         case unsignedPayload
         case s3chunked
     }
-    
+
     /// `signURL` and `signHeaders` make assumptions about the URLs they are provided, this function cleans up a URL so it is ready
     /// to be signed by either of these functions. It sorts the query params and ensures they are properly percent encoded
     public func processURL(url: URL) -> URL? {
@@ -64,7 +64,7 @@ public struct AWSSigner {
         urlComponents.percentEncodedQuery = urlQueryString
         return urlComponents.url
     }
-    
+
     /// Generate signed headers, for a HTTP request
     public func signHeaders(url: URL, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: BodyData? = nil, date: Date = Date()) -> HTTPHeaders {
         let bodyHash = AWSSigner.hashedPayload(body)

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -236,8 +236,12 @@ public struct AWSSigner {
             .sorted { $0.key < $1.key }
             .map { return "\($0.key):\($0.value.trimmingCharacters(in: CharacterSet.whitespaces))" }
             .joined(separator: "\n")
+        var canonicalPath = signingData.unsignedURL.pathWithSlash.uriEncodeWithSlash()
+        if name != "s3" {
+            canonicalPath = canonicalPath.uriEncodeWithSlash()
+        }
         let canonicalRequest = "\(signingData.method.rawValue)\n" +
-            "\(signingData.unsignedURL.pathWithSlash.uriEncodeWithSlash())\n" +
+            "\(canonicalPath)\n" +
             "\(signingData.unsignedURL.query ?? "")\n" + // should really uriEncode all the query string values
             "\(canonicalHeaders)\n\n" +
             "\(signingData.signedHeaders)\n" +

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -58,7 +58,12 @@ public struct AWSSigner {
     public func processURL(url: URL) -> URL? {
         guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
         let urlQueryString = urlComponents.queryItems?
-            .sorted { $0.name < $1.name }
+            .sorted {
+                if $0.name < $1.name { return true }
+                if $0.name > $1.name { return false }
+                guard let value1 = $0.value, let value2 = $1.value else { return false }
+                return value1 < value2
+            }
             .map { item in item.value.map { "\(item.name)=\($0.uriEncode())" } ?? item.name }
             .joined(separator: "&")
         urlComponents.percentEncodedQuery = urlQueryString

--- a/Tests/SotoCoreTests/AWSRequestTests.swift
+++ b/Tests/SotoCoreTests/AWSRequestTests.swift
@@ -322,4 +322,16 @@ class AWSRequestTests: XCTestCase {
         XCTAssertNoThrow(request = try AWSRequest(operation: "Test", path: "/{path}", httpMethod: .GET, input: input, configuration: config))
         XCTAssertEqual(request?.url, URL(string: "https://test.com/Test%20me%2Fonce%2B")!)
     }
+
+    func testSortedArrayQuery() {
+        struct Input: AWSEncodableShape {
+            static let _encoding: [AWSMemberEncoding] = [.init(label: "items", location: .querystring(locationName: "item"))]
+            let items: [String]
+        }
+        let input = Input(items: ["orange", "apple"])
+        let config = createServiceConfig(endpoint: "https://test.com")
+        var request: AWSRequest?
+        XCTAssertNoThrow(request = try AWSRequest(operation: "Test", path: "/", httpMethod: .GET, input: input, configuration: config))
+        XCTAssertEqual(request?.url, URL(string: "https://test.com/?item=apple&item=orange")!)
+    }
 }

--- a/Tests/SotoCoreTests/AWSServiceTests.swift
+++ b/Tests/SotoCoreTests/AWSServiceTests.swift
@@ -71,7 +71,7 @@ class AWSServiceTests: XCTestCase {
     }
 
     func testSignURL() throws {
-        let client = createAWSClient()
+        let client = createAWSClient(credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"))
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
         let serviceConfig = createServiceConfig()
         let service = TestService(client: client, config: serviceConfig)

--- a/Tests/SotoCoreTests/AWSServiceTests.swift
+++ b/Tests/SotoCoreTests/AWSServiceTests.swift
@@ -88,4 +88,20 @@ class AWSServiceTests: XCTestCase {
             .joined(separator: "&")
         XCTAssertEqual(queryItems, "percent=addi%2Btion&space=sp%20ace&test2=true")
     }
+
+    func testSignHeaders() throws {
+        let client = createAWSClient(credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"))
+        defer { XCTAssertNoThrow(try client.syncShutdown()) }
+        let serviceConfig = createServiceConfig()
+        let service = TestService(client: client, config: serviceConfig)
+        let url = URL(string: "https://test.amazonaws.com?test2=true&space=sp%20ace&percent=addi+tion")!
+        let headers = try service.signHeaders(
+            url: url,
+            httpMethod: .GET,
+            headers: ["Content-Type": "application/json"],
+            body: .string("Test payload")
+        ).wait()
+        // remove signed query params
+        XCTAssertNotNil(headers["Authorization"].first)
+    }
 }

--- a/Tests/SotoSignerV4Tests/AWSSignerTests.swift
+++ b/Tests/SotoSignerV4Tests/AWSSignerTests.swift
@@ -81,7 +81,7 @@ final class AWSSignerTests: XCTestCase {
         let url3 = URL(string: "https://test.s3.amazonaws.com?test=hello%20goodbye")!
         XCTAssertEqual(signer.processURL(url: url3), URL(string: "https://test.s3.amazonaws.com?test=hello%20goodbye"))
     }
-    
+
     func testSignS3PutWithHeaderURL() {
         let signer = AWSSigner(credentials: credentialsWithSessionKey, name: "s3", region: "eu-west-1")
         let url = signer.signURL(

--- a/Tests/SotoSignerV4Tests/AWSSignerTests.swift
+++ b/Tests/SotoSignerV4Tests/AWSSignerTests.swift
@@ -72,6 +72,16 @@ final class AWSSignerTests: XCTestCase {
         XCTAssertEqual(url.absoluteString, "https://test-bucket.s3.amazonaws.com/test-put.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=MYACCESSKEY%2F20010102%2Feu-west-1%2Fs3%2Faws4_request&X-Amz-Date=20010102T034640Z&X-Amz-Expires=86400&X-Amz-Security-Token=MYSESSIONTOKEN&X-Amz-SignedHeaders=host&X-Amz-Signature=969dfbc450089f34f5b430611b18def1701c72c9e7e1608142051a898094227e")
     }
 
+    func testProcessURL() {
+        let signer = AWSSigner(credentials: credentials, name: "s3", region: "eu-west-1")
+        let url = URL(string: "https://test.s3.amazonaws.com?test2=true&test1=false")!
+        XCTAssertEqual(signer.processURL(url: url), URL(string: "https://test.s3.amazonaws.com?test1=false&test2=true"))
+        let url2 = URL(string: "https://test.s3.amazonaws.com?test=hello+goodbye")!
+        XCTAssertEqual(signer.processURL(url: url2), URL(string: "https://test.s3.amazonaws.com?test=hello%2Bgoodbye"))
+        let url3 = URL(string: "https://test.s3.amazonaws.com?test=hello%20goodbye")!
+        XCTAssertEqual(signer.processURL(url: url3), URL(string: "https://test.s3.amazonaws.com?test=hello%20goodbye"))
+    }
+    
     func testSignS3PutWithHeaderURL() {
         let signer = AWSSigner(credentials: credentialsWithSessionKey, name: "s3", region: "eu-west-1")
         let url = signer.signURL(


### PR DESCRIPTION
See https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html for details
- Percent encode paths twice if service isn't s3 
- Order query params first by key and if keys are equal then by value
- Add `AWSSigner.processURL` to clean a URL before passing to signer (use in `AWSClient.signURL`)
- Add `AWSClient.signHeaders` which returns signed headers instead of a signed URL. (useful for Elasticsearch which needs signed headers instead of a signed URL)