### PR TITLE
Support credential_source in config file

### DIFF
--- a/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
@@ -87,23 +87,16 @@ class ConfigFileCredentialProvider: CredentialProviderSelector {
         switch sharedCredentials {
         case .staticCredential(let staticCredential):
             return staticCredential
-        case .assumeRole(let roleArn, let sessionName, let region, let sourceCredential):
+        case .assumeRole(let roleArn, let sessionName, let region, let sourceCredentialProvider):
             let request = STSAssumeRoleRequest(roleArn: roleArn, roleSessionName: sessionName)
-            let provider = CredentialProviderFactory.static(
-                accessKeyId: sourceCredential.accessKeyId,
-                secretAccessKey: sourceCredential.secretAccessKey,
-                sessionToken: sourceCredential.sessionToken
-            )
             let region = region ?? .useast1
             return STSAssumeRoleCredentialProvider(
                 request: request,
-                credentialProvider: provider,
+                credentialProvider: sourceCredentialProvider,
                 region: region,
                 httpClient: context.httpClient,
                 endpoint: endpoint
             )
-        case .credentialSource:
-            throw CredentialProviderError.notSupported
         }
     }
 }

--- a/Sources/SotoCore/Credential/CredentialProviderError.swift
+++ b/Sources/SotoCore/Credential/CredentialProviderError.swift
@@ -15,13 +15,11 @@
 public struct CredentialProviderError: Error, Equatable {
     enum _CredentialProviderError {
         case noProvider
-        case notSupported
     }
 
     let error: _CredentialProviderError
 
     public static var noProvider: CredentialProviderError { return .init(error: .noProvider) }
-    public static var notSupported: CredentialProviderError { return .init(error: .notSupported) }
 }
 
 extension CredentialProviderError: CustomStringConvertible {
@@ -29,8 +27,6 @@ extension CredentialProviderError: CustomStringConvertible {
         switch self.error {
         case .noProvider:
             return "No credential provider found"
-        case .notSupported:
-            return "Credential method not supported"
         }
     }
 }

--- a/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
@@ -155,7 +155,7 @@ class ConfigFileCredentialProviderTests: XCTestCase {
         role_arn = \(roleArn)
         credential_source = Environment
         """
-        
+
         Environment.set(accessKey, for: "AWS_ACCESS_KEY_ID")
         Environment.set(secretKey, for: "AWS_SECRET_ACCESS_KEY")
         defer {

--- a/Tests/SotoCoreTests/Credential/ConfigFileLoaderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileLoaderTests.swift
@@ -110,8 +110,8 @@ class ConfigFileLoadersTests: XCTestCase {
             context: context
         ).wait()
 
-        defer { XCTAssertNoThrow(try httpClient.syncShutdown())}
-        
+        defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
+
         switch sharedCredentials {
         case .assumeRole(let aRoleArn, let aSessionName, let region, let sourceCredentialProvider):
             let credentials = try sourceCredentialProvider.createProvider(context: context).getCredential(on: context.eventLoop, logger: context.logger).wait()


### PR DESCRIPTION
Removed enum case `credentialSource` instead use `assumeRole` for both source_profile and credential_source. Instead of it holding a `StaticCredential` it now holds a `CredentialProviderFactory`. In the situation we are dealing with source_profile this is set to `.static()`. For `credential_source` we use one of `.environment`, `.ec2`, `.ecs`.

Add test, testing with environment credential