### PR TITLE
Add support for output CustomCoding values in headers and querys

### DIFF
--- a/Sources/SotoCore/Encoder/CodableProperties/CodableProperties.swift
+++ b/Sources/SotoCore/Encoder/CodableProperties/CodableProperties.swift
@@ -21,7 +21,14 @@ public protocol CustomCoder {
 
 /// Protocol for object that will encode a value
 public protocol CustomEncoder: CustomCoder {
+    /// encode CodableValue with supplied encoder
     static func encode(value: CodableValue, to encoder: Encoder) throws
+    /// return value as a String. Used by query string and header values
+    static func string(from: CodableValue) -> String?
+}
+
+extension CustomEncoder {
+    public static func string(from: CodableValue) -> String? { return nil }
 }
 
 /// Protocol for object that will decode a value

--- a/Sources/SotoCore/Encoder/CodableProperties/DateCoders.swift
+++ b/Sources/SotoCore/Encoder/CodableProperties/DateCoders.swift
@@ -46,6 +46,10 @@ extension DateFormatCoder {
         try container.encode(dateFormatters[0].string(from: value))
     }
 
+    public static func string(from value: Date) -> String? {
+        dateFormatters[0].string(from: value)
+    }
+
     /// create DateFormatter
     static func createDateFormatters() -> [DateFormatter] {
         var dateFormatters: [DateFormatter] = []

--- a/Tests/SotoCoreTests/AWSRequestTests.swift
+++ b/Tests/SotoCoreTests/AWSRequestTests.swift
@@ -337,11 +337,16 @@ class AWSRequestTests: XCTestCase {
 
     func testCustomEncoderInQuery() {
         struct Input: AWSEncodableShape {
-            static let _encoding: [AWSMemberEncoding] = [.init(label: "_date", location: .querystring(locationName: "date"))]
+            static let _encoding: [AWSMemberEncoding] = [
+                .init(label: "_date", location: .querystring(locationName: "date")),
+                .init(label: "_values", location: .querystring(locationName: "values")),
+            ]
             @OptionalCustomCoding<HTTPHeaderDateCoder>
             var date: Date?
+            @CustomCoding<StandardArrayCoder>
+            var values: [Int]
         }
-        let input = Input(date: Date(timeIntervalSince1970: 10_000_000))
+        let input = Input(date: Date(timeIntervalSince1970: 10_000_000), values: [1])
         let config = createServiceConfig(endpoint: "https://test.com")
         var request: AWSRequest?
         XCTAssertNoThrow(request = try AWSRequest(operation: "Test", path: "/", httpMethod: .GET, input: input, configuration: config))

--- a/Tests/SotoCoreTests/AWSRequestTests.swift
+++ b/Tests/SotoCoreTests/AWSRequestTests.swift
@@ -334,4 +334,17 @@ class AWSRequestTests: XCTestCase {
         XCTAssertNoThrow(request = try AWSRequest(operation: "Test", path: "/", httpMethod: .GET, input: input, configuration: config))
         XCTAssertEqual(request?.url, URL(string: "https://test.com/?item=apple&item=orange")!)
     }
+
+    func testCustomEncoderInQuery() {
+        struct Input: AWSEncodableShape {
+            static let _encoding: [AWSMemberEncoding] = [.init(label: "_date", location: .querystring(locationName: "date"))]
+            @OptionalCustomCoding<HTTPHeaderDateCoder>
+            var date: Date?
+        }
+        let input = Input(date: Date(timeIntervalSince1970: 10_000_000))
+        let config = createServiceConfig(endpoint: "https://test.com")
+        var request: AWSRequest?
+        XCTAssertNoThrow(request = try AWSRequest(operation: "Test", path: "/", httpMethod: .GET, input: input, configuration: config))
+        XCTAssertEqual(request?.url, URL(string: "https://test.com/?date=Sun%2C%2026%20Apr%201970%2017%3A46%3A40%20GMT")!)
+    }
 }


### PR DESCRIPTION
CustomEncoder protocol has new `string(from: CodableValue)` function. If you implement this then the wrapped value will be returned. Otherwise nothing will be output