### PR TITLE
Logging level changes

### DIFF
--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -173,7 +173,7 @@ public final class AWSClient {
                 self.httpClient.shutdown(queue: queue) { error in
                     if let error = error {
                         self.clientLogger.log(level: self.options.errorLogLevel, "Error shutting down HTTP client", metadata: [
-                            "aws-error": "\(error)"
+                            "aws-error": "\(error)",
                         ])
                     }
                     callback(error)
@@ -571,7 +571,7 @@ extension AWSClient {
         // if we can create an AWSResponse and create an error from it return that
         if let awsResponse = try? AWSResponse(from: response, serviceProtocol: serviceConfig.serviceProtocol)
             .applyMiddlewares(serviceConfig.middlewares + middlewares, config: serviceConfig),
-           let error = awsResponse.generateError(serviceConfig: serviceConfig, logLevel: options.errorLogLevel, logger: logger)
+            let error = awsResponse.generateError(serviceConfig: serviceConfig, logLevel: options.errorLogLevel, logger: logger)
         {
             return error
         } else {

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -86,7 +86,8 @@ public final class AWSClient {
         self.credentialProvider = credentialProviderFactory.createProvider(context: .init(
             httpClient: httpClient,
             eventLoop: httpClient.eventLoopGroup.next(),
-            logger: clientLogger
+            logger: clientLogger,
+            options: options
         ))
 
         self.middlewares = middlewares

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -171,8 +171,8 @@ public final class AWSClient {
             case .createNew, .createNewWithEventLoopGroup:
                 self.httpClient.shutdown(queue: queue) { error in
                     if let error = error {
-                        self.clientLogger.error("Error shutting down HTTP client", metadata: [
-                            "aws-error": "\(error)",
+                        self.clientLogger.log(level: self.options.errorLogLevel, "Error shutting down HTTP client", metadata: [
+                            "aws-error": "\(error)"
                         ])
                     }
                     callback(error)
@@ -230,7 +230,7 @@ public final class AWSClient {
         /// - Parameter requestLogLevel:Log level used for request logging
         public init(
             requestLogLevel: Logger.Level = .debug,
-            errorLogLevel: Logger.Level = .info
+            errorLogLevel: Logger.Level = .debug
         ) {
             self.requestLogLevel = requestLogLevel
             self.errorLogLevel = errorLogLevel
@@ -570,7 +570,7 @@ extension AWSClient {
         // if we can create an AWSResponse and create an error from it return that
         if let awsResponse = try? AWSResponse(from: response, serviceProtocol: serviceConfig.serviceProtocol)
             .applyMiddlewares(serviceConfig.middlewares + middlewares, config: serviceConfig),
-            let error = awsResponse.generateError(serviceConfig: serviceConfig, logger: logger)
+           let error = awsResponse.generateError(serviceConfig: serviceConfig, logLevel: options.errorLogLevel, logger: logger)
         {
             return error
         } else {

--- a/Sources/SotoCore/Credential/CredentialProvider.swift
+++ b/Sources/SotoCore/Credential/CredentialProvider.swift
@@ -48,6 +48,8 @@ public struct CredentialProviderFactory {
         public let eventLoop: EventLoop
         /// The `Logger` attached to the AWSClient
         public let logger: Logger
+        /// AWSClient options
+        public let options: AWSClient.Options
     }
 
     private let cb: (Context) -> CredentialProvider

--- a/Sources/SotoCore/Credential/DeferredCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/DeferredCredentialProvider.swift
@@ -49,7 +49,7 @@ public class DeferredCredentialProvider: CredentialProvider {
             .flatMapErrorThrowing { _ in throw CredentialProviderError.noProvider }
             .map { credential in
                 self.credential = credential
-                context.logger.info("AWS credentials ready", metadata: ["aws-credential-provider": .string("\(self)")])
+                context.logger.debug("AWS credentials ready", metadata: ["aws-credential-provider": .string("\(self)")])
                 return credential
             }
             .cascade(to: self.startupPromise)

--- a/Sources/SotoCore/Credential/MetaDataCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/MetaDataCredentialProvider.swift
@@ -183,14 +183,14 @@ struct InstanceMetaDataClient: MetaDataClient {
     func getMetaData(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<InstanceMetaData> {
         return getToken(on: eventLoop, logger: logger)
             .map { token in
-                logger.info("Found IMDSv2 token")
+                logger.trace("Found IMDSv2 token")
                 return HTTPHeaders([(Self.TokenHeaderName, token)])
             }
             .flatMapErrorThrowing { _ in
                 // If we didn't find a session key then assume we are running IMDSv1.
                 // (we could be running from a Docker container and the hop count for the PUT
                 // request is still set to 1)
-                logger.info("Did not find IMDSv2 token, use IMDSv1")
+                logger.trace("Did not find IMDSv2 token, use IMDSv1")
                 return HTTPHeaders()
             }
             .flatMap { (headers) -> EventLoopFuture<(AWSHTTPResponse, HTTPHeaders)> in

--- a/Sources/SotoCore/Credential/RotatingCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/RotatingCredentialProvider.swift
@@ -81,7 +81,7 @@ public final class RotatingCredentialProvider: CredentialProvider {
             return future
         }
 
-        logger.info("Refeshing AWS credentials", metadata: ["aws-credential-provider": .string("\(self)")])
+        logger.debug("Refeshing AWS credentials", metadata: ["aws-credential-provider": .string("\(self)")])
 
         credentialFuture = self.provider.getCredential(on: eventLoop, logger: logger)
             .map { (credential) -> (Credential) in
@@ -89,7 +89,7 @@ public final class RotatingCredentialProvider: CredentialProvider {
                 self.lock.withLock {
                     self.credentialFuture = nil
                     self.credential = credential
-                    logger.info("AWS credentials ready", metadata: ["aws-credential-provider": .string("\(self)")])
+                    logger.debug("AWS credentials ready", metadata: ["aws-credential-provider": .string("\(self)")])
                 }
                 return credential
             }

--- a/Sources/SotoCore/Credential/RuntimeSelectorCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/RuntimeSelectorCredentialProvider.swift
@@ -47,9 +47,10 @@ class RuntimeSelectorCredentialProvider: CredentialProviderSelector {
             provider.getCredential(on: context.eventLoop, logger: context.logger).whenComplete { result in
                 switch result {
                 case .success:
-                    context.logger.info("Select credential provider", metadata: ["aws-credential-provider": .string("\(provider)")])
+                    context.logger.debug("Select credential provider", metadata: ["aws-credential-provider": .string("\(provider)")])
                     self.startupPromise.succeed(provider)
                 case .failure:
+                    context.logger.log(level: context.options.errorLogLevel, "Select credential provider failed")
                     _setupInternalProvider(index + 1)
                 }
             }

--- a/Sources/SotoCore/Message/AWSResponse.swift
+++ b/Sources/SotoCore/Message/AWSResponse.swift
@@ -181,7 +181,7 @@ public struct AWSResponse {
     }
 
     /// extract error code and message from AWSResponse
-    func generateError(serviceConfig: AWSServiceConfig, logger: Logger) -> Error? {
+    func generateError(serviceConfig: AWSServiceConfig, logLevel: Logger.Level = .info, logger: Logger) -> Error? {
         var apiError: APIError?
         switch serviceConfig.serviceProtocol {
         case .restjson:
@@ -225,7 +225,7 @@ public struct AWSResponse {
                 code = String(code[code.index(index, offsetBy: 1)...])
             }
 
-            logger.error("AWS Error", metadata: [
+            logger.log(level: logLevel, "AWS Error", metadata: [
                 "aws-error-code": .string(code),
                 "aws-error-message": .string(errorMessage.message),
             ])

--- a/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
@@ -27,7 +27,7 @@ class ConfigFileCredentialProviderTests: XCTestCase {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let eventLoop = eventLoopGroup.next()
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoop))
-        return (.init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger), eventLoopGroup, httpClient)
+        return (.init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger, options: .init()), eventLoopGroup, httpClient)
     }
 
     func testCredentialProviderStatic() {
@@ -89,7 +89,7 @@ class ConfigFileCredentialProviderTests: XCTestCase {
         defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
         let factory = CredentialProviderFactory.configFile(credentialsFilePath: filenameURL.path)
 
-        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger))
+        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger, options: .init()))
 
         var credential: Credential?
         XCTAssertNoThrow(credential = try provider.getCredential(on: eventLoop, logger: TestEnvironment.logger).wait())
@@ -118,7 +118,7 @@ class ConfigFileCredentialProviderTests: XCTestCase {
         defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
         let factory = CredentialProviderFactory.configFile(credentialsFilePath: filenameURL.path)
 
-        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger))
+        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger, options: .init()))
 
         var credential: Credential?
         XCTAssertNoThrow(credential = try provider.getCredential(on: eventLoop, logger: TestEnvironment.logger).wait())
@@ -137,7 +137,7 @@ class ConfigFileCredentialProviderTests: XCTestCase {
         defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
         let factory = CredentialProviderFactory.configFile(credentialsFilePath: filenameURL.path)
 
-        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger))
+        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger, options: .init()))
 
         XCTAssertThrowsError(_ = try provider.getCredential(on: eventLoop, logger: TestEnvironment.logger).wait()) { error in
             print("\(error)")

--- a/Tests/SotoCoreTests/Credential/ConfigFileLoaderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileLoaderTests.swift
@@ -27,7 +27,7 @@ class ConfigFileLoadersTests: XCTestCase {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let eventLoop = eventLoopGroup.next()
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoop))
-        return (.init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger), eventLoopGroup, httpClient)
+        return (.init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger, options: .init()), eventLoopGroup, httpClient)
     }
 
     func save(content: String, prefix: String) throws -> String {

--- a/Tests/SotoCoreTests/Credential/CredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/CredentialProviderTests.swift
@@ -51,7 +51,7 @@ class CredentialProviderTests: XCTestCase {
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
         defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
         let eventLoop = eventLoopGroup.next()
-        let context = CredentialProviderFactory.Context(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger)
+        let context = CredentialProviderFactory.Context(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger, options: .init())
         let deferredProvider = DeferredCredentialProvider(context: context, provider: MyCredentialProvider())
         XCTAssertNoThrow(_ = try deferredProvider.getCredential(on: eventLoop, logger: TestEnvironment.logger).wait())
         XCTAssertNoThrow(_ = try deferredProvider.getCredential(on: eventLoop, logger: TestEnvironment.logger).wait())
@@ -75,7 +75,7 @@ class CredentialProviderTests: XCTestCase {
         defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
         let factory = CredentialProviderFactory.configFile(credentialsFilePath: filenameURL.path)
 
-        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger))
+        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger, options: .init()))
 
         var credential: Credential?
         XCTAssertNoThrow(credential = try provider.getCredential(on: eventLoop, logger: TestEnvironment.logger).wait())
@@ -94,7 +94,7 @@ class CredentialProviderTests: XCTestCase {
         defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
         let factory = CredentialProviderFactory.configFile(credentialsFilePath: filenameURL.path)
 
-        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger))
+        let provider = factory.createProvider(context: .init(httpClient: httpClient, eventLoop: eventLoop, logger: TestEnvironment.logger, options: .init()))
 
         XCTAssertThrowsError(_ = try provider.getCredential(on: eventLoop, logger: TestEnvironment.logger).wait()) { error in
             print("\(error)")

--- a/Tests/SotoCoreTests/Credential/RotatingCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/RotatingCredentialProviderTests.swift
@@ -54,7 +54,7 @@ class RotatingCredentialProviderTests: XCTestCase {
             hitCount += 1
             return $0.makeSucceededFuture(cred)
         }
-        let context = CredentialProviderFactory.Context(httpClient: httpClient, eventLoop: loop, logger: Logger(label: "soto"))
+        let context = CredentialProviderFactory.Context(httpClient: httpClient, eventLoop: loop, logger: Logger(label: "soto"), options: .init())
         let provider = RotatingCredentialProvider(context: context, provider: client)
 
         // get credentials for first time
@@ -98,7 +98,7 @@ class RotatingCredentialProviderTests: XCTestCase {
             hitCount += 1
             return promise.futureResult
         }
-        let context = CredentialProviderFactory.Context(httpClient: httpClient, eventLoop: loop, logger: TestEnvironment.logger)
+        let context = CredentialProviderFactory.Context(httpClient: httpClient, eventLoop: loop, logger: TestEnvironment.logger, options: .init())
         let provider = RotatingCredentialProvider(context: context, provider: client)
 
         var resultFutures = [EventLoopFuture<Void>]()
@@ -159,7 +159,7 @@ class RotatingCredentialProviderTests: XCTestCase {
             )
             return eventLoop.makeSucceededFuture(cred)
         }
-        let context = CredentialProviderFactory.Context(httpClient: httpClient, eventLoop: loop, logger: TestEnvironment.logger)
+        let context = CredentialProviderFactory.Context(httpClient: httpClient, eventLoop: loop, logger: TestEnvironment.logger, options: .init())
         let provider = RotatingCredentialProvider(context: context, provider: client)
         XCTAssertNoThrow(_ = try provider.getCredential(on: loop, logger: TestEnvironment.logger).wait())
         hitCount = 0

--- a/Tests/SotoCoreTests/LoggingTests.swift
+++ b/Tests/SotoCoreTests/LoggingTests.swift
@@ -100,6 +100,7 @@ class LoggingTests: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop()) }
         let client = AWSClient(
             credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"),
+            options: .init(requestLogLevel: .debug, errorLogLevel: .info),
             httpClientProvider: .createNew,
             logger: logger
         )
@@ -117,7 +118,7 @@ class LoggingTests: XCTestCase {
 
         XCTAssertThrowsError(_ = try response.wait())
         XCTAssertEqual(logCollection.filter(metadata: "aws-error-code", with: "AccessDenied").first?.message, "AWS Error")
-        XCTAssertEqual(logCollection.filter(metadata: "aws-error-code", with: "AccessDenied").first?.level, .error)
+        XCTAssertEqual(logCollection.filter(metadata: "aws-error-code", with: "AccessDenied").first?.level, .info)
     }
 
     func testRetryRequest() {


### PR DESCRIPTION
More logging level changes

In general downgrading or using levels set in options
- AWSResponse uses error level from AWSClient
- Metadata credential provider uses trace for logging where IMDS token is coming from
- Extend `CredentialProviderContext` to include `AWSClient.options` and use error logging level in `RuntimeSelectorCredentialProvider`