### PR TITLE
Remove hack to fix issues with AHC backpressure

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.16.1")),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMajor(from: "2.7.2")),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.2.0")),
+        .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.3.0")),
     ],
     targets: [
         .target(name: "SotoCore", dependencies: [

--- a/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
@@ -80,12 +80,6 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
                 deadline: .now() + timeout,
                 logger: logger
             ).futureResult
-                // temporarily wait on delegate response finishing while AHC does not do this for us. See https://github.com/swift-server/async-http-client/issues/274
-                .flatMap { response in
-                    // if delegate future
-                    guard let futureResult = delegate.bodyPartFuture else { return eventLoop.makeSucceededFuture(response) }
-                    return futureResult.map { return response }
-                }
         } catch {
             return eventLoopGroup.next().makeFailedFuture(error)
         }

--- a/Sources/SotoCore/HTTP/ResponseDelegate.swift
+++ b/Sources/SotoCore/HTTP/ResponseDelegate.swift
@@ -31,9 +31,6 @@ class AWSHTTPClientResponseDelegate: HTTPClientResponseDelegate {
     let host: String
     let stream: (ByteBuffer, EventLoop) -> EventLoopFuture<Void>
     var state: State
-    // temporary stored future while AHC still doesn't sync to futures returned from `didReceiveBodyPart`
-    // See https://github.com/swift-server/async-http-client/issues/274
-    var bodyPartFuture: EventLoopFuture<Void>?
 
     init(host: String, stream: @escaping (ByteBuffer, EventLoop) -> EventLoopFuture<Void>) {
         self.host = host
@@ -62,7 +59,6 @@ class AWSHTTPClientResponseDelegate: HTTPClientResponseDelegate {
         case .head(let head):
             if (200..<300).contains(head.status.code) {
                 let futureResult = self.stream(part, task.eventLoop)
-                self.bodyPartFuture = futureResult
                 return futureResult
             }
             self.state = .head(head)


### PR DESCRIPTION
Before AsyncHTTPClient v1.3.0 if you implemented your own `ResponseDelegate` the `EventLoopFuture` that `HTTPClient.execute` returns could complete before your delegate had finished processing the body parts. I had to add a hack to the `AWSClient` streaming response delegate to ensure we returned after all processing had been done by adding an additional promise to the delegate and then waiting on that promise completing before I could guarantee the delegate had done its work.

Now AHC v1.3.0 is out I can remove this hack. 