### PR TITLE
Run request init and signing on a NIOThreadPool

### DIFF
--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -226,15 +226,19 @@ public final class AWSClient {
         let requestLogLevel: Logger.Level
         /// log level used for error logging
         let errorLogLevel: Logger.Level
+        /// thread pool
+        let threadPool: NIOThreadPool?
 
         /// Initialize AWSClient.Options
         /// - Parameter requestLogLevel:Log level used for request logging
         public init(
             requestLogLevel: Logger.Level = .debug,
-            errorLogLevel: Logger.Level = .debug
+            errorLogLevel: Logger.Level = .debug,
+            threadPool: NIOThreadPool? = nil
         ) {
             self.requestLogLevel = requestLogLevel
             self.errorLogLevel = errorLogLevel
+            self.threadPool = threadPool
         }
     }
 }

--- a/Tests/SotoCoreTests/AWSClientTests.swift
+++ b/Tests/SotoCoreTests/AWSClientTests.swift
@@ -269,14 +269,15 @@ class AWSClientTests: XCTestCase {
     func testRequestS3Streaming() {
         let threadPool = NIOThreadPool(numberOfThreads: 2)
         threadPool.start()
-        defer { XCTAssertNoThrow(try threadPool.syncShutdownGracefully())}
+        defer { XCTAssertNoThrow(try threadPool.syncShutdownGracefully()) }
         let awsServer = AWSTestServer(serviceProtocol: .json)
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
         let config = createServiceConfig(service: "s3", endpoint: awsServer.address)
         let client = createAWSClient(
             credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"),
             options: .init(threadPool: threadPool),
-            httpClientProvider: .shared(httpClient))
+            httpClientProvider: .shared(httpClient)
+        )
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
             XCTAssertNoThrow(try awsServer.stop())
@@ -304,7 +305,7 @@ class AWSClientTests: XCTestCase {
 
         let threadPool = NIOThreadPool(numberOfThreads: 2)
         threadPool.start()
-        defer { XCTAssertNoThrow(try threadPool.syncShutdownGracefully())}
+        defer { XCTAssertNoThrow(try threadPool.syncShutdownGracefully()) }
 
         let awsServer = AWSTestServer(serviceProtocol: .json)
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)


### PR DESCRIPTION
We are doing this to take the generation of requests off the EventLoop as it not a cheap operation.

Add optional `NIOThreadPool` to `AWSClient.Options`
If thread pool is non-nil then use it for running the creation and signing of Requests