### PR TITLE
Add support for waiters using JMESPath

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
             .product(name: "NIOSSL", package: "swift-nio-ssl"),
             .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
             .product(name: "NIOFoundationCompat", package: "swift-nio"),
-            .product(name: "JMESPath", package: "jmespath.swift")
+            .product(name: "JMESPath", package: "jmespath.swift"),
         ]),
         .target(name: "SotoCrypto", dependencies: []),
         .target(name: "SotoSignerV4", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMajor(from: "2.7.2")),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.3.0")),
-        .package(url: "https://github.com/adam-fowler/jmespath.swift.git", .upToNextMajor(from: "0.2.0")),
+        .package(url: "https://github.com/adam-fowler/jmespath.swift.git", .branch("jmes-property-wrapper")),
     ],
     targets: [
         .target(name: "SotoCore", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMajor(from: "2.7.2")),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", .upToNextMajor(from: "1.0.0")),
         .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.3.0")),
+        .package(url: "https://github.com/adam-fowler/jmespath.swift.git", .upToNextMajor(from: "0.2.0")),
     ],
     targets: [
         .target(name: "SotoCore", dependencies: [
@@ -43,6 +44,7 @@ let package = Package(
             .product(name: "NIOSSL", package: "swift-nio-ssl"),
             .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
             .product(name: "NIOFoundationCompat", package: "swift-nio"),
+            .product(name: "JMESPath", package: "jmespath.swift")
         ]),
         .target(name: "SotoCrypto", dependencies: []),
         .target(name: "SotoSignerV4", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -25,11 +25,11 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.16.1")),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", .upToNextMajor(from: "2.7.2")),
-        .package(url: "https://github.com/apple/swift-nio-transport-services.git", .upToNextMajor(from: "1.0.0")),
-        .package(url: "https://github.com/swift-server/async-http-client.git", .upToNextMajor(from: "1.3.0")),
-        .package(url: "https://github.com/adam-fowler/jmespath.swift.git", .branch("jmes-property-wrapper")),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.16.1"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.7.2"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.0.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.3.0"),
+        .package(url: "https://github.com/adam-fowler/jmespath.swift.git", from: "1.0.0"),
     ],
     targets: [
         .target(name: "SotoCore", dependencies: [

--- a/Sources/SotoCore/AWSClient+Paginate.swift
+++ b/Sources/SotoCore/AWSClient+Paginate.swift
@@ -15,6 +15,8 @@
 import Logging
 import NIO
 
+// MARK: Pagination
+
 /// protocol for all AWSShapes that can be paginated.
 /// Adds an initialiser that does a copy but inserts a new integer based pagination token
 public protocol AWSPaginateToken: AWSShape {

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -195,6 +195,7 @@ public final class AWSClient {
             case tooMuchData
             case notEnoughData
             case waiterFailed
+            case waiterTimeout
         }
 
         let error: Error
@@ -207,8 +208,10 @@ public final class AWSClient {
         public static var tooMuchData: ClientError { .init(error: .tooMuchData) }
         /// Not enough data has been supplied for the Request
         public static var notEnoughData: ClientError { .init(error: .notEnoughData) }
-        /// Not enough data has been supplied for the Request
+        /// Waiter failed, but without an error. ie a successful api call was an error
         public static var waiterFailed: ClientError { .init(error: .waiterFailed) }
+        /// Waiter failed to complete in time alloted
+        public static var waiterTimeout: ClientError { .init(error: .waiterTimeout) }
     }
 
     /// Specifies how `HTTPClient` will be created and establishes lifecycle ownership.
@@ -663,6 +666,8 @@ extension AWSClient.ClientError: CustomStringConvertible {
             return "You have not supplied enough data for the Request."
         case .waiterFailed:
             return "Waiter failed"
+        case .waiterTimeout:
+            return "Waiter failed to complete in time allocated"
         }
     }
 }

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -194,6 +194,7 @@ public final class AWSClient {
             case invalidURL
             case tooMuchData
             case notEnoughData
+            case waiterFailed
         }
 
         let error: Error
@@ -206,6 +207,8 @@ public final class AWSClient {
         public static var tooMuchData: ClientError { .init(error: .tooMuchData) }
         /// Not enough data has been supplied for the Request
         public static var notEnoughData: ClientError { .init(error: .notEnoughData) }
+        /// Not enough data has been supplied for the Request
+        public static var waiterFailed: ClientError { .init(error: .waiterFailed) }
     }
 
     /// Specifies how `HTTPClient` will be created and establishes lifecycle ownership.
@@ -658,6 +661,8 @@ extension AWSClient.ClientError: CustomStringConvertible {
             return "You have supplied too much data for the Request."
         case .notEnoughData:
             return "You have not supplied enough data for the Request."
+        case .waiterFailed:
+            return "Waiter failed"
         }
     }
 }

--- a/Sources/SotoCore/Encoder/CodableProperties/CodableProperties.swift
+++ b/Sources/SotoCore/Encoder/CodableProperties/CodableProperties.swift
@@ -107,6 +107,7 @@ extension OptionalCustomCoding: JMESPropertyWrapper {
         return self.value as Any
     }
 }
+
 /// Protocol for a PropertyWrapper to properly handle CustomCoding when the wrappedValue is Optional
 public protocol OptionalCustomCodingWrapper {
     associatedtype WrappedType

--- a/Sources/SotoCore/Encoder/CodableProperties/CodableProperties.swift
+++ b/Sources/SotoCore/Encoder/CodableProperties/CodableProperties.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 // This code takes inspiration from https://github.com/GottaGetSwifty/CodableWrappers
+import JMESPath
 
 /// base protocol for encoder/decoder objects
 public protocol CustomCoder {
@@ -37,11 +38,7 @@ public protocol CustomDecoder: CustomCoder {
 }
 
 /// Property wrapper that applies a custom encoder and decoder to its wrapped value
-@propertyWrapper public struct CustomCoding<Coder: CustomCoder>: CustomReflectable {
-    public var customMirror: Mirror {
-        return Mirror(reflecting: wrappedValue)
-    }
-
+@propertyWrapper public struct CustomCoding<Coder: CustomCoder> {
     var value: Coder.CodableValue
 
     public init(wrappedValue value: Coder.CodableValue) {
@@ -68,12 +65,15 @@ extension CustomCoding: Encodable where Coder: CustomEncoder {
     }
 }
 
-/// Property wrapper that applies a custom encoder and decoder to its wrapped optional value
-@propertyWrapper public struct OptionalCustomCoding<Coder: CustomCoder>: CustomReflectable {
-    public var customMirror: Mirror {
-        return Mirror(reflecting: wrappedValue)
+/// extend CustomCoding property wrapper so JMESPath works correctly with it
+extension CustomCoding: JMESPropertyWrapper {
+    public var anyValue: Any {
+        return self.value
     }
+}
 
+/// Property wrapper that applies a custom encoder and decoder to its wrapped optional value
+@propertyWrapper public struct OptionalCustomCoding<Coder: CustomCoder> {
     var value: Coder.CodableValue?
 
     public init(wrappedValue value: Coder.CodableValue?) {
@@ -101,6 +101,12 @@ extension OptionalCustomCoding: Encodable where Coder: CustomEncoder {
     }
 }
 
+/// extend OptionalCustomCoding property wrapper so JMESPath works correctly with it
+extension OptionalCustomCoding: JMESPropertyWrapper {
+    public var anyValue: Any {
+        return self.value as Any
+    }
+}
 /// Protocol for a PropertyWrapper to properly handle CustomCoding when the wrappedValue is Optional
 public protocol OptionalCustomCodingWrapper {
     associatedtype WrappedType

--- a/Sources/SotoCore/Encoder/CodableProperties/CodableProperties.swift
+++ b/Sources/SotoCore/Encoder/CodableProperties/CodableProperties.swift
@@ -37,7 +37,11 @@ public protocol CustomDecoder: CustomCoder {
 }
 
 /// Property wrapper that applies a custom encoder and decoder to its wrapped value
-@propertyWrapper public struct CustomCoding<Coder: CustomCoder> {
+@propertyWrapper public struct CustomCoding<Coder: CustomCoder>: CustomReflectable {
+    public var customMirror: Mirror {
+        return Mirror(reflecting: wrappedValue)
+    }
+
     var value: Coder.CodableValue
 
     public init(wrappedValue value: Coder.CodableValue) {
@@ -65,7 +69,11 @@ extension CustomCoding: Encodable where Coder: CustomEncoder {
 }
 
 /// Property wrapper that applies a custom encoder and decoder to its wrapped optional value
-@propertyWrapper public struct OptionalCustomCoding<Coder: CustomCoder> {
+@propertyWrapper public struct OptionalCustomCoding<Coder: CustomCoder>: CustomReflectable {
+    public var customMirror: Mirror {
+        return Mirror(reflecting: wrappedValue)
+    }
+
     var value: Coder.CodableValue?
 
     public init(wrappedValue value: Coder.CodableValue?) {

--- a/Sources/SotoCore/Waiters/AWSClient+Waiter.swift
+++ b/Sources/SotoCore/Waiters/AWSClient+Waiter.swift
@@ -66,7 +66,7 @@ extension AWSClient {
         let maxDelayTime: TimeAmount
         let command: (Input, Logger, EventLoop?) -> EventLoopFuture<Output>
 
-        /// calculate delay until next API call. This calculation comes from the AWS Smithy documentation
+        /// Calculate delay until next API call. This calculation comes from the AWS Smithy documentation
         /// https://awslabs.github.io/smithy/1.0/spec/waiters.html#waiter-retries
         func calculateRetryWaitTime(attempt: Int, remainingTime: TimeAmount) -> TimeAmount {
             let minDelay = Double(self.minDelayTime.nanoseconds) / 1_000_000_000
@@ -88,8 +88,8 @@ extension AWSClient {
         }
     }
 
-    /// Return EventLoopFuture that will by fulfilled once waiter polling returns a success state
-    /// or will return an error if the polling returns an error or timesout
+    /// Returns an `EventLoopFuture` that will by fulfilled once waiter polling returns a success state
+    /// or returns an error if the polling returns an error or timesout
     ///
     /// - Parameters:
     ///   - input: Input parameters
@@ -113,24 +113,24 @@ extension AWSClient {
         func attempt(number: Int) {
             waiter.command(input, logger, eventLoop)
                 .whenComplete { result in
-                    var state: WaiterState?
+                    var acceptorState: WaiterState?
                     for acceptor in waiter.acceptors {
                         if acceptor.matcher.match(result: result.map { $0 }) {
-                            state = acceptor.state
+                            acceptorState = acceptor.state
                             break
                         }
                     }
                     // if state has not been set then set it based on return of API call
-                    let solidState: WaiterState
-                    if let state = state {
-                        solidState = state
+                    let waiterState: WaiterState
+                    if let state = acceptorState {
+                        waiterState = state
                     } else if case .failure = result {
-                        solidState = .failure
+                        waiterState = .failure
                     } else {
-                        solidState = .retry
+                        waiterState = .retry
                     }
                     // based on state succeed, fail promise or retry
-                    switch solidState {
+                    switch waiterState {
                     case .success:
                         promise.succeed(())
                     case .failure:

--- a/Sources/SotoCore/Waiters/AWSClient+Waiter.swift
+++ b/Sources/SotoCore/Waiters/AWSClient+Waiter.swift
@@ -105,7 +105,7 @@ extension AWSClient {
         logger: Logger = AWSClient.loggingDisabled,
         on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Void> {
-        let maxWaitTime = maxWaitTime ?? .seconds(120)
+        let maxWaitTime = maxWaitTime ?? waiter.maxDelayTime
         let deadline: NIODeadline = .now() + maxWaitTime
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let promise = eventLoop.makePromise(of: Void.self)
@@ -144,7 +144,7 @@ extension AWSClient {
                         if wait < .seconds(0) {
                             promise.fail(ClientError.waiterTimeout)
                         } else {
-                            logger.info("Wait \(wait.nanoseconds / 1_000_000)ms")
+                            logger.trace("Wait \(wait.nanoseconds / 1_000_000)ms")
                             eventLoop.scheduleTask(in: wait) { attempt(number: number + 1) }
                         }
                     }

--- a/Sources/SotoCore/Waiters/AWSClient+Waiter.swift
+++ b/Sources/SotoCore/Waiters/AWSClient+Waiter.swift
@@ -66,7 +66,8 @@ extension AWSClient {
         let maxDelayTime: TimeAmount
         let command: (Input, Logger, EventLoop?) -> EventLoopFuture<Output>
 
-        /// calculate delay until next API call
+        /// calculate delay until next API call. This calculation comes from the AWS Smithy documentation
+        /// https://awslabs.github.io/smithy/1.0/spec/waiters.html#waiter-retries
         func calculateRetryWaitTime(attempt: Int, remainingTime: TimeAmount) -> TimeAmount {
             let minDelay = Double(self.minDelayTime.nanoseconds) / 1_000_000_000
             let maxDelay = Double(self.maxDelayTime.nanoseconds) / 1_000_000_000
@@ -87,7 +88,9 @@ extension AWSClient {
         }
     }
 
-    /// Return EventLoopFuture that will by fulfilled once waiter is done
+    /// Return EventLoopFuture that will by fulfilled once waiter polling returns a success state
+    /// or will return an error if the polling returns an error or timesout
+    ///
     /// - Parameters:
     ///   - input: Input parameters
     ///   - waiter: Waiter to wait on
@@ -95,7 +98,7 @@ extension AWSClient {
     ///   - logger: Logger used to provide output
     ///   - eventLoop: EventLoop to run API calls on
     /// - Returns: EventLoopFuture that will be fulfilled once waiter has completed
-    public func wait<Input, Output>(
+    public func waitUntil<Input, Output>(
         _ input: Input,
         waiter: Waiter<Input, Output>,
         maxWaitTime: TimeAmount = .seconds(120),

--- a/Sources/SotoCore/Waiters/AWSClient+Waiter.swift
+++ b/Sources/SotoCore/Waiters/AWSClient+Waiter.swift
@@ -101,10 +101,11 @@ extension AWSClient {
     public func waitUntil<Input, Output>(
         _ input: Input,
         waiter: Waiter<Input, Output>,
-        maxWaitTime: TimeAmount = .seconds(120),
+        maxWaitTime: TimeAmount? = nil,
         logger: Logger = AWSClient.loggingDisabled,
         on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Void> {
+        let maxWaitTime = maxWaitTime ?? .seconds(120)
         let deadline: NIODeadline = .now() + maxWaitTime
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         let promise = eventLoop.makePromise(of: Void.self)

--- a/Sources/SotoCore/Waiters/AWSClient+Waiter.swift
+++ b/Sources/SotoCore/Waiters/AWSClient+Waiter.swift
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2020 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+extension AWSClient {
+    enum WaiterState {
+        case success
+        case retry
+        case failure
+    }
+
+    struct Waiter<Input, Output> {
+        struct Acceptor {
+            let state: WaiterState
+            let matcher: AWSMatcher
+        }
+        let acceptors: [Acceptor]
+        let maxRetryAttempts: Int
+        let command: (Input, Logger, EventLoop?) -> EventLoopFuture<Output>
+    }
+
+    func wait<Input, Output>(
+        _ input: Input,
+        waiter: Waiter<Input, Output>,
+        maxWaitTime: TimeAmount,
+        logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil
+    ) -> EventLoopFuture<Void> {
+        let eventLoop = eventLoop ?? eventLoopGroup.next()
+        let promise = eventLoop.makePromise(of: Void.self)
+
+        func attempt() {
+            waiter.command(input, logger, eventLoop)
+                .whenComplete { result in
+                    var state: WaiterState? = nil
+                    for acceptor in waiter.acceptors {
+                        if acceptor.matcher.match(result: result.map { $0 }) {
+                            state = acceptor.state
+                            break
+                        }
+                    }
+                    print(state)
+                    switch state {
+                    case .success:
+                        promise.succeed(())
+                    case .failure:
+                        if case .failure(let error) = result {
+                            promise.fail(error)
+                        } else {
+                            promise.fail(ClientError.waiterFailed)
+                        }
+                    case .retry:
+                        eventLoop.scheduleTask(in: .seconds(1)) { attempt() }
+                    case .none:
+                        if case .failure(let error) = result {
+                            promise.fail(error)
+                        } else {
+                            eventLoop.scheduleTask(in: .seconds(1)) { attempt() }
+                        }
+                    }
+                }
+        }
+        attempt()
+        return promise.futureResult
+    }
+}

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -34,7 +34,7 @@ public struct JMESPathMatcher<Value: CustomStringConvertible>: AWSWaiterMatcher 
         case .success(let output):
             do {
                 if let result = try expression.search(object: output) as? CustomStringConvertible {
-                    return expected == result.description
+                    return self.expected == result.description
                 } else {
                     return false
                 }

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -50,9 +50,9 @@ public struct AWSSuccessMatcher: AWSWaiterMatcher {
 }
 
 public struct AWSErrorStatusMatcher: AWSWaiterMatcher {
-    let expectedStatus: HTTPResponseStatus
+    let expectedStatus: Int
 
-    public init(_ status: HTTPResponseStatus) {
+    public init(_ status: Int) {
         self.expectedStatus = status
     }
 
@@ -61,7 +61,11 @@ public struct AWSErrorStatusMatcher: AWSWaiterMatcher {
         case .success:
             return false
         case.failure(let error):
-            return (error as? AWSErrorType)?.context?.responseCode == expectedStatus
+            if let code = (error as? AWSErrorType)?.context?.responseCode.code {
+                return code == self.expectedStatus
+            } else {
+                return false
+            }
         }
     }
 }

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIO
+import NIOHTTP1
 
 public protocol AWSWaiterMatcher {
     func match(result: Result<Any, Error>) -> Bool
@@ -44,6 +45,23 @@ public struct AWSSuccessMatcher: AWSWaiterMatcher {
             return true
         case.failure:
             return false
+        }
+    }
+}
+
+public struct AWSErrorStatusMatcher: AWSWaiterMatcher {
+    let expectedStatus: HTTPResponseStatus
+
+    public init(_ status: HTTPResponseStatus) {
+        self.expectedStatus = status
+    }
+
+    public func match(result: Result<Any, Error>) -> Bool {
+        switch result {
+        case .success:
+            return false
+        case.failure(let error):
+            return (error as? AWSErrorType)?.context?.responseCode == expectedStatus
         }
     }
 }

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2020 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+protocol AWSMatcher {
+    func match(result: Result<Any, Error>) -> Bool
+}
+
+struct AWSOutputMatcher<Value: Equatable>: AWSMatcher {
+    let path: AnyKeyPath
+    let expected: Value
+
+    func match(result: Result<Any, Error>) -> Bool {
+        switch result {
+        case .success(let output):
+            return (output[keyPath: path] as? Value) == expected
+        case.failure:
+            return false
+        }
+    }
+}
+
+struct AWSSuccessMatcher: AWSMatcher {
+    func match(result: Result<Any, Error>) -> Bool {
+        switch result {
+        case .success:
+            return true
+        case.failure:
+            return false
+        }
+    }
+}
+
+struct AWSErrorMatcher: AWSMatcher {
+    let expected: AWSErrorType
+
+    func match(result: Result<Any, Error>) -> Bool {
+        switch result {
+        case .success:
+            return false
+        case.failure(let error):
+            return (error as? AWSErrorType)?.errorCode == expected.errorCode
+        }
+    }
+}

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -27,12 +27,12 @@ public struct AWSPathMatcher<Object, Value: Equatable>: AWSWaiterMatcher {
         self.path = path
         self.expected = expected
     }
-    
+
     public func match(result: Result<Any, Error>) -> Bool {
         switch result {
         case .success(let output):
-            return (output as? Object)?[keyPath: path] == expected
-        case.failure:
+            return (output as? Object)?[keyPath: self.path] == self.expected
+        case .failure:
             return false
         }
     }
@@ -43,7 +43,7 @@ public struct AWSSuccessMatcher: AWSWaiterMatcher {
         switch result {
         case .success:
             return true
-        case.failure:
+        case .failure:
             return false
         }
     }
@@ -60,7 +60,7 @@ public struct AWSErrorStatusMatcher: AWSWaiterMatcher {
         switch result {
         case .success:
             return false
-        case.failure(let error):
+        case .failure(let error):
             if let code = (error as? AWSErrorType)?.context?.responseCode.code {
                 return code == self.expectedStatus
             } else {
@@ -76,13 +76,13 @@ public struct AWSErrorCodeMatcher: AWSWaiterMatcher {
     public init(_ code: String) {
         self.expectedCode = code
     }
-    
+
     public func match(result: Result<Any, Error>) -> Bool {
         switch result {
         case .success:
             return false
-        case.failure(let error):
-            return (error as? AWSErrorType)?.errorCode == expectedCode
+        case .failure(let error):
+            return (error as? AWSErrorType)?.errorCode == self.expectedCode
         }
     }
 }

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -48,11 +48,11 @@ public struct AWSSuccessMatcher: AWSWaiterMatcher {
     }
 }
 
-public struct AWSErrorMatcher: AWSWaiterMatcher {
-    let expected: AWSErrorType
+public struct AWSErrorCodeMatcher: AWSWaiterMatcher {
+    let expectedCode: String
 
-    public init(_ expected: AWSErrorType) {
-        self.expected = expected
+    public init(_ code: String) {
+        self.expectedCode = code
     }
     
     public func match(result: Result<Any, Error>) -> Bool {
@@ -60,7 +60,7 @@ public struct AWSErrorMatcher: AWSWaiterMatcher {
         case .success:
             return false
         case.failure(let error):
-            return (error as? AWSErrorType)?.errorCode == expected.errorCode
+            return (error as? AWSErrorType)?.errorCode == expectedCode
         }
     }
 }

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -18,12 +18,12 @@ import NIOHTTP1
 
 /// Protocol for matchers used in waiters.
 ///
-/// A matcher returns whether returned value from API call matches a certain state
+/// A matcher returns whether the returned value from an AWS API call matches a certain state
 public protocol AWSWaiterMatcher {
     func match(result: Result<Any, Error>) -> Bool
 }
 
-/// Match whether value indicated by JMESPath matches an expected value
+/// Match whether the value indicated by JMESPath matches an expected value
 public struct JMESPathMatcher<Value: CustomStringConvertible>: AWSWaiterMatcher {
     let expression: JMESExpression
     let expected: String
@@ -37,8 +37,8 @@ public struct JMESPathMatcher<Value: CustomStringConvertible>: AWSWaiterMatcher 
         switch result {
         case .success(let output):
             do {
-                if let result = try expression.search(object: output) as? CustomStringConvertible {
-                    return self.expected == result.description
+                if let searchResult = try expression.search(object: output, as: CustomStringConvertible.self) {
+                    return self.expected == searchResult.description
                 } else {
                     return false
                 }
@@ -65,8 +65,8 @@ public struct JMESAnyPathMatcher<Value: CustomStringConvertible>: AWSWaiterMatch
         switch result {
         case .success(let output):
             do {
-                if let result = try expression.search(object: output, as: [Any].self) {
-                    return result.first { expected == ($0 as? CustomStringConvertible)?.description } != nil
+                if let searchResult = try expression.search(object: output, as: [CustomStringConvertible].self) {
+                    return searchResult.first { expected == $0.description } != nil
                 } else {
                     return false
                 }
@@ -93,8 +93,8 @@ public struct JMESAllPathMatcher<Value: CustomStringConvertible>: AWSWaiterMatch
         switch result {
         case .success(let output):
             do {
-                if let result = try expression.search(object: output, as: [Any].self) {
-                    return result.first { expected != ($0 as? CustomStringConvertible)?.description } == nil
+                if let searchResult = try expression.search(object: output, as: [CustomStringConvertible].self) {
+                    return searchResult.first { expected != $0.description } == nil
                 } else {
                     return false
                 }
@@ -107,7 +107,7 @@ public struct JMESAllPathMatcher<Value: CustomStringConvertible>: AWSWaiterMatch
     }
 }
 
-/// Match whether a call was successful
+/// Match whether an AWS API call was successful
 public struct AWSSuccessMatcher: AWSWaiterMatcher {
     public init() {}
     public func match(result: Result<Any, Error>) -> Bool {
@@ -120,7 +120,7 @@ public struct AWSSuccessMatcher: AWSWaiterMatcher {
     }
 }
 
-/// Match whether a call return a specific HTTP response code
+/// Match whether an AWS API call returns a specific HTTP response code
 public struct AWSErrorStatusMatcher: AWSWaiterMatcher {
     let expectedStatus: Int
 
@@ -146,7 +146,7 @@ public struct AWSErrorStatusMatcher: AWSWaiterMatcher {
     }
 }
 
-/// Match whether a call returned a specific error code
+/// Match whether an AWS API call returns a specific error code
 public struct AWSErrorCodeMatcher: AWSWaiterMatcher {
     let expectedCode: String
 

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -18,11 +18,11 @@ public protocol AWSWaiterMatcher {
     func match(result: Result<Any, Error>) -> Bool
 }
 
-public struct AWSOutputMatcher<Value: Equatable>: AWSWaiterMatcher {
-    let path: AnyKeyPath
+public struct AWSPathMatcher<Object, Value: Equatable>: AWSWaiterMatcher {
+    let path: KeyPath<Object, Value>
     let expected: Value
 
-    public init(path: AnyKeyPath, expected: Value) {
+    public init(path: KeyPath<Object, Value>, expected: Value) {
         self.path = path
         self.expected = expected
     }
@@ -30,7 +30,7 @@ public struct AWSOutputMatcher<Value: Equatable>: AWSWaiterMatcher {
     public func match(result: Result<Any, Error>) -> Bool {
         switch result {
         case .success(let output):
-            return (output[keyPath: path] as? Value) == expected
+            return (output as? Object)?[keyPath: path] == expected
         case.failure:
             return false
         }

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -122,6 +122,7 @@ public struct AWSAllPathMatcher<Object, Group: Collection, Value: Equatable>: AW
 }
 
 public struct AWSSuccessMatcher: AWSWaiterMatcher {
+    public init() {}
     public func match(result: Result<Any, Error>) -> Bool {
         switch result {
         case .success:

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -14,15 +14,20 @@
 
 import NIO
 
-protocol AWSMatcher {
+public protocol AWSMatcher {
     func match(result: Result<Any, Error>) -> Bool
 }
 
-struct AWSOutputMatcher<Value: Equatable>: AWSMatcher {
+public struct AWSOutputMatcher<Value: Equatable>: AWSMatcher {
     let path: AnyKeyPath
     let expected: Value
 
-    func match(result: Result<Any, Error>) -> Bool {
+    public init(path: AnyKeyPath, expected: Value) {
+        self.path = path
+        self.expected = expected
+    }
+    
+    public func match(result: Result<Any, Error>) -> Bool {
         switch result {
         case .success(let output):
             return (output[keyPath: path] as? Value) == expected
@@ -32,8 +37,8 @@ struct AWSOutputMatcher<Value: Equatable>: AWSMatcher {
     }
 }
 
-struct AWSSuccessMatcher: AWSMatcher {
-    func match(result: Result<Any, Error>) -> Bool {
+public struct AWSSuccessMatcher: AWSMatcher {
+    public func match(result: Result<Any, Error>) -> Bool {
         switch result {
         case .success:
             return true
@@ -43,10 +48,14 @@ struct AWSSuccessMatcher: AWSMatcher {
     }
 }
 
-struct AWSErrorMatcher: AWSMatcher {
+public struct AWSErrorMatcher: AWSMatcher {
     let expected: AWSErrorType
 
-    func match(result: Result<Any, Error>) -> Bool {
+    public init(_ expected: AWSErrorType) {
+        self.expected = expected
+    }
+    
+    public func match(result: Result<Any, Error>) -> Bool {
         switch result {
         case .success:
             return false

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -14,11 +14,11 @@
 
 import NIO
 
-public protocol AWSMatcher {
+public protocol AWSWaiterMatcher {
     func match(result: Result<Any, Error>) -> Bool
 }
 
-public struct AWSOutputMatcher<Value: Equatable>: AWSMatcher {
+public struct AWSOutputMatcher<Value: Equatable>: AWSWaiterMatcher {
     let path: AnyKeyPath
     let expected: Value
 
@@ -37,7 +37,7 @@ public struct AWSOutputMatcher<Value: Equatable>: AWSMatcher {
     }
 }
 
-public struct AWSSuccessMatcher: AWSMatcher {
+public struct AWSSuccessMatcher: AWSWaiterMatcher {
     public func match(result: Result<Any, Error>) -> Bool {
         switch result {
         case .success:
@@ -48,7 +48,7 @@ public struct AWSSuccessMatcher: AWSMatcher {
     }
 }
 
-public struct AWSErrorMatcher: AWSMatcher {
+public struct AWSErrorMatcher: AWSWaiterMatcher {
     let expected: AWSErrorType
 
     public init(_ expected: AWSErrorType) {

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -56,7 +56,7 @@ public struct AWSAnyPathMatcher<Object, Element, Value: Equatable>: AWSWaiterMat
             guard let array = (output as? Object)?[keyPath: self.arrayPath] else {
                 return false
             }
-            return array.first { $0[keyPath: elementPath] == expected} != nil
+            return array.first { $0[keyPath: elementPath] == expected } != nil
         case .failure:
             return false
         }
@@ -81,7 +81,7 @@ public struct AWSAllPathMatcher<Object, Element, Value: Equatable>: AWSWaiterMat
             guard let array = (output as? Object)?[keyPath: self.arrayPath] else {
                 return false
             }
-            return array.first { $0[keyPath: elementPath] != expected} == nil
+            return array.first { $0[keyPath: elementPath] != expected } == nil
         case .failure:
             return false
         }

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -16,10 +16,14 @@ import JMESPath
 import NIO
 import NIOHTTP1
 
+/// Protocol for matchers used in waiters.
+///
+/// A matcher returns whether returned value from API call matches a certain state
 public protocol AWSWaiterMatcher {
     func match(result: Result<Any, Error>) -> Bool
 }
 
+/// Match whether value indicated by JMESPath matches an expected value
 public struct JMESPathMatcher<Value: CustomStringConvertible>: AWSWaiterMatcher {
     let expression: JMESExpression
     let expected: String
@@ -47,6 +51,7 @@ public struct JMESPathMatcher<Value: CustomStringConvertible>: AWSWaiterMatcher 
     }
 }
 
+/// Match whether any of the values indicated by JMESPath matches an expected value
 public struct JMESAnyPathMatcher<Value: CustomStringConvertible>: AWSWaiterMatcher {
     let expression: JMESExpression
     let expected: String
@@ -74,6 +79,7 @@ public struct JMESAnyPathMatcher<Value: CustomStringConvertible>: AWSWaiterMatch
     }
 }
 
+/// Match whether all of the values indicated by JMESPath matches an expected value
 public struct JMESAllPathMatcher<Value: CustomStringConvertible>: AWSWaiterMatcher {
     let expression: JMESExpression
     let expected: String
@@ -101,6 +107,7 @@ public struct JMESAllPathMatcher<Value: CustomStringConvertible>: AWSWaiterMatch
     }
 }
 
+/// Match whether a call was successful
 public struct AWSSuccessMatcher: AWSWaiterMatcher {
     public init() {}
     public func match(result: Result<Any, Error>) -> Bool {
@@ -113,6 +120,7 @@ public struct AWSSuccessMatcher: AWSWaiterMatcher {
     }
 }
 
+/// Match whether a call return a specific HTTP response code
 public struct AWSErrorStatusMatcher: AWSWaiterMatcher {
     let expectedStatus: Int
 
@@ -138,6 +146,7 @@ public struct AWSErrorStatusMatcher: AWSWaiterMatcher {
     }
 }
 
+/// Match whether a call returned a specific error code
 public struct AWSErrorCodeMatcher: AWSWaiterMatcher {
     let expectedCode: String
 

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -144,12 +144,16 @@ public struct AWSErrorStatusMatcher: AWSWaiterMatcher {
         switch result {
         case .success:
             return false
-        case .failure(let error):
-            if let code = (error as? AWSErrorType)?.context?.responseCode.code {
+        case .failure(let error as AWSErrorType):
+            if let code = error.context?.responseCode.code {
                 return code == self.expectedStatus
             } else {
                 return false
             }
+        case .failure(let error as AWSRawError):
+            return error.context.responseCode.code == self.expectedStatus
+        case .failure:
+            return false
         }
     }
 }

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -65,7 +65,7 @@ public struct AWSAnyPathMatcher<Object, Group: Collection, Value: Equatable>: AW
         case .success(let output):
             // get array
             let array: Group?
-            switch arrayPath {
+            switch self.arrayPath {
             case .nonOptional(let keyPath):
                 array = (output as? Object)?[keyPath: keyPath]
             case .optional(let keyPath):
@@ -104,7 +104,7 @@ public struct AWSAllPathMatcher<Object, Group: Collection, Value: Equatable>: AW
         case .success(let output):
             // get array
             let array: Group?
-            switch arrayPath {
+            switch self.arrayPath {
             case .nonOptional(let keyPath):
                 array = (output as? Object)?[keyPath: keyPath]
             case .optional(let keyPath):

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -38,12 +38,12 @@ public struct AWSPathMatcher<Object, Value: Equatable>: AWSWaiterMatcher {
     }
 }
 
-public struct AWSAnyPathMatcher<Object, Element, Value: Equatable>: AWSWaiterMatcher {
-    let arrayPath: KeyPath<Object, [Element]>
-    let elementPath: KeyPath<Element, Value>
+public struct AWSAnyPathMatcher<Object, Group: Collection, Value: Equatable>: AWSWaiterMatcher {
+    let arrayPath: KeyPath<Object, Group>
+    let elementPath: KeyPath<Group.Element, Value>
     let expected: Value
 
-    public init(arrayPath: KeyPath<Object, [Element]>, elementPath: KeyPath<Element, Value>, expected: Value) {
+    public init(arrayPath: KeyPath<Object, Group>, elementPath: KeyPath<Group.Element, Value>, expected: Value) {
         self.arrayPath = arrayPath
         self.elementPath = elementPath
         self.expected = expected
@@ -63,12 +63,12 @@ public struct AWSAnyPathMatcher<Object, Element, Value: Equatable>: AWSWaiterMat
     }
 }
 
-public struct AWSAllPathMatcher<Object, Element, Value: Equatable>: AWSWaiterMatcher {
-    let arrayPath: KeyPath<Object, [Element]>
-    let elementPath: KeyPath<Element, Value>
+public struct AWSAllPathMatcher<Object, Group: Collection, Value: Equatable>: AWSWaiterMatcher {
+    let arrayPath: KeyPath<Object, Group>
+    let elementPath: KeyPath<Group.Element, Value>
     let expected: Value
 
-    public init(arrayPath: KeyPath<Object, [Element]>, elementPath: KeyPath<Element, Value>, expected: Value) {
+    public init(arrayPath: KeyPath<Object, Group>, elementPath: KeyPath<Group.Element, Value>, expected: Value) {
         self.arrayPath = arrayPath
         self.elementPath = elementPath
         self.expected = expected

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -38,6 +38,56 @@ public struct AWSPathMatcher<Object, Value: Equatable>: AWSWaiterMatcher {
     }
 }
 
+public struct AWSAnyPathMatcher<Object, Element, Value: Equatable>: AWSWaiterMatcher {
+    let arrayPath: KeyPath<Object, [Element]>
+    let elementPath: KeyPath<Element, Value>
+    let expected: Value
+
+    public init(arrayPath: KeyPath<Object, [Element]>, elementPath: KeyPath<Element, Value>, expected: Value) {
+        self.arrayPath = arrayPath
+        self.elementPath = elementPath
+        self.expected = expected
+    }
+
+    public func match(result: Result<Any, Error>) -> Bool {
+        switch result {
+        case .success(let output):
+            // get array
+            guard let array = (output as? Object)?[keyPath: self.arrayPath] else {
+                return false
+            }
+            return array.first { $0[keyPath: elementPath] == expected} != nil
+        case .failure:
+            return false
+        }
+    }
+}
+
+public struct AWSAllPathMatcher<Object, Element, Value: Equatable>: AWSWaiterMatcher {
+    let arrayPath: KeyPath<Object, [Element]>
+    let elementPath: KeyPath<Element, Value>
+    let expected: Value
+
+    public init(arrayPath: KeyPath<Object, [Element]>, elementPath: KeyPath<Element, Value>, expected: Value) {
+        self.arrayPath = arrayPath
+        self.elementPath = elementPath
+        self.expected = expected
+    }
+
+    public func match(result: Result<Any, Error>) -> Bool {
+        switch result {
+        case .success(let output):
+            // get array
+            guard let array = (output as? Object)?[keyPath: self.arrayPath] else {
+                return false
+            }
+            return array.first { $0[keyPath: elementPath] != expected} == nil
+        case .failure:
+            return false
+        }
+    }
+}
+
 public struct AWSSuccessMatcher: AWSWaiterMatcher {
     public func match(result: Result<Any, Error>) -> Bool {
         switch result {

--- a/Sources/SotoCore/Waiters/Matcher.swift
+++ b/Sources/SotoCore/Waiters/Matcher.swift
@@ -71,10 +71,11 @@ public struct AWSAnyPathMatcher<Object, Group: Collection, Value: Equatable>: AW
             case .optional(let keyPath):
                 array = (output as? Object)?[keyPath: keyPath]
             }
-            guard let array = array else {
+            if let array = array {
+                return array.first { $0[keyPath: elementPath] == expected } != nil
+            } else {
                 return false
             }
-            return array.first { $0[keyPath: elementPath] == expected } != nil
         case .failure:
             return false
         }
@@ -109,10 +110,11 @@ public struct AWSAllPathMatcher<Object, Group: Collection, Value: Equatable>: AW
             case .optional(let keyPath):
                 array = (output as? Object)?[keyPath: keyPath]
             }
-            guard let array = array else {
+            if let array = array {
+                return array.first { $0[keyPath: elementPath] != expected } == nil
+            } else {
                 return false
             }
-            return array.first { $0[keyPath: elementPath] != expected } == nil
         case .failure:
             return false
         }

--- a/Tests/SotoCoreTests/WaiterTests.swift
+++ b/Tests/SotoCoreTests/WaiterTests.swift
@@ -50,6 +50,7 @@ class WaiterTests: XCTestCase {
             init(booleanLiteral: Bool) {
                 self.status = booleanLiteral
             }
+
             init(_ status: Bool) {
                 self.status = status
             }
@@ -80,7 +81,7 @@ class WaiterTests: XCTestCase {
     func testJMESPathWaiter() {
         let waiter = AWSClient.Waiter(
             acceptors: [
-                .init(state: .success, matcher: try! JMESPathMatcher("array[*].status", expected: [true,true,true])),
+                .init(state: .success, matcher: try! JMESPathMatcher("array[*].status", expected: [true, true, true])),
             ],
             minDelayTime: .seconds(2),
             command: self.arrayOperation
@@ -227,7 +228,7 @@ class WaiterTests: XCTestCase {
 
         let waiter = AWSClient.Waiter(
             acceptors: [
-                .init(state: .success, matcher: try! JMESPathMatcher("array[*]", expected: [true,true,true])),
+                .init(state: .success, matcher: try! JMESPathMatcher("array[*]", expected: [true, true, true])),
             ],
             minDelayTime: .seconds(2),
             command: arrayOperation

--- a/Tests/SotoCoreTests/WaiterTests.swift
+++ b/Tests/SotoCoreTests/WaiterTests.swift
@@ -47,7 +47,7 @@ class WaiterTests: XCTestCase {
     func testBasicWaiter() {
         let waiter = AWSClient.Waiter(
             acceptors: [
-                .init(state: .success, matcher: AWSOutputMatcher(path: \Output.i, expected: 3))
+                .init(state: .success, matcher: AWSPathMatcher(path: \Output.i, expected: 3))
             ],
             minDelayTime: .seconds(2),
             maxDelayTime: .seconds(4),
@@ -68,7 +68,7 @@ class WaiterTests: XCTestCase {
     func testTimeoutWaiter() {
         let waiter = AWSClient.Waiter(
             acceptors: [
-                .init(state: .success, matcher: AWSOutputMatcher(path: \Output.i, expected: 3))
+                .init(state: .success, matcher: AWSPathMatcher(path: \Output.i, expected: 3))
             ],
             minDelayTime: .seconds(2),
             maxDelayTime: .seconds(4),
@@ -97,7 +97,7 @@ class WaiterTests: XCTestCase {
         let waiter = AWSClient.Waiter(
             acceptors: [
                 .init(state: .retry, matcher: AWSErrorMatcher(AWSClientError.accessDenied)),
-                .init(state: .success, matcher: AWSOutputMatcher(path: \Output.i, expected: 3))
+                .init(state: .success, matcher: AWSPathMatcher(path: \Output.i, expected: 3))
             ],
             minDelayTime: .seconds(2),
             maxDelayTime: .seconds(4),

--- a/Tests/SotoCoreTests/WaiterTests.swift
+++ b/Tests/SotoCoreTests/WaiterTests.swift
@@ -80,7 +80,6 @@ class WaiterTests: XCTestCase {
                 .init(state: .success, matcher: AWSPathMatcher(path: \Output.i, expected: 3)),
             ],
             minDelayTime: .seconds(2),
-            maxDelayTime: .seconds(4),
             command: self.operation
         )
         let input = Input()
@@ -101,7 +100,6 @@ class WaiterTests: XCTestCase {
                 .init(state: .success, matcher: AWSAnyPathMatcher(arrayPath: \ArrayOutput.array, elementPath: \ArrayOutput.Element.status, expected: true)),
             ],
             minDelayTime: .seconds(2),
-            maxDelayTime: .seconds(4),
             command: self.arrayOperation
         )
         let input = Input()
@@ -126,7 +124,6 @@ class WaiterTests: XCTestCase {
                 .init(state: .success, matcher: AWSAnyPathMatcher(arrayPath: \OptionalArrayOutput.array, elementPath: \OptionalArrayOutput.Element.status, expected: true)),
             ],
             minDelayTime: .seconds(2),
-            maxDelayTime: .seconds(4),
             command: self.optionalArrayOperation
         )
         let input = Input()
@@ -151,7 +148,6 @@ class WaiterTests: XCTestCase {
                 .init(state: .success, matcher: AWSAllPathMatcher(arrayPath: \ArrayOutput.array, elementPath: \ArrayOutput.Element.status, expected: true)),
             ],
             minDelayTime: .seconds(2),
-            maxDelayTime: .seconds(4),
             command: self.arrayOperation
         )
         let input = Input()
@@ -176,7 +172,6 @@ class WaiterTests: XCTestCase {
                 .init(state: .success, matcher: AWSAllPathMatcher(arrayPath: \OptionalArrayOutput.array, elementPath: \OptionalArrayOutput.Element.status, expected: true)),
             ],
             minDelayTime: .seconds(2),
-            maxDelayTime: .seconds(4),
             command: self.optionalArrayOperation
         )
         let input = Input()
@@ -230,7 +225,6 @@ class WaiterTests: XCTestCase {
                 .init(state: .success, matcher: AWSPathMatcher(path: \Output.i, expected: 3)),
             ],
             minDelayTime: .seconds(2),
-            maxDelayTime: .seconds(4),
             command: self.operation
         )
         let input = Input()
@@ -256,7 +250,6 @@ class WaiterTests: XCTestCase {
                 .init(state: .success, matcher: AWSPathMatcher(path: \Output.i, expected: 3)),
             ],
             minDelayTime: .seconds(2),
-            maxDelayTime: .seconds(4),
             command: self.operation
         )
         let input = Input()

--- a/Tests/SotoCoreTests/WaiterTests.swift
+++ b/Tests/SotoCoreTests/WaiterTests.swift
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2021 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AsyncHTTPClient
+import NIO
+@testable import SotoCore
+import SotoTestUtils
+import XCTest
+
+class WaiterTests: XCTestCase {
+    func testBasicWaiter() {
+        let awsServer = AWSTestServer(serviceProtocol: .json)
+        let config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
+        let client = createAWSClient(credentialProvider: .empty, middlewares: [AWSLoggingMiddleware()])
+        defer {
+            XCTAssertNoThrow(try client.syncShutdown())
+            XCTAssertNoThrow(try awsServer.stop())
+        }
+
+        struct Input: AWSEncodableShape & Decodable {
+            let i: Int
+        }
+        struct Output: AWSDecodableShape & Encodable {
+            let i: Int
+        }
+        func operation(input: Input, logger: Logger, eventLoop: EventLoop?) -> EventLoopFuture<Output> {
+            client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: logger, on: eventLoop)
+        }
+        let waiter = AWSClient.Waiter(
+            acceptors: [.init(state: .success, matcher: AWSOutputMatcher(path: \Output.i, expected: 3))],
+            maxRetryAttempts: 20,
+            command: operation
+        )
+        do {
+            let input = Input(i: 1)
+            let response = client.wait(input, waiter: waiter, maxWaitTime: .seconds(20), logger: TestEnvironment.logger)
+
+            var i = 0
+            try awsServer.process { (request: Input) -> AWSTestServer.Result<Output> in
+                //let receivedInput = try JSONDecoder().decode(Input.self, from: request.body)
+                i += 1
+                return .result(Output(i: i), continueProcessing: i < 3)
+            }
+
+            try response.wait()
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+}

--- a/Tests/SotoCoreTests/WaiterTests.swift
+++ b/Tests/SotoCoreTests/WaiterTests.swift
@@ -51,8 +51,10 @@ class WaiterTests: XCTestCase {
                 self.status = booleanLiteral
             }
         }
+
         let array: [Element]
     }
+
     func arrayOperation(input: Input, logger: Logger, eventLoop: EventLoop?) -> EventLoopFuture<ArrayOutput> {
         Self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: Self.config, input: input, logger: logger, on: eventLoop)
     }

--- a/Tests/SotoCoreTests/WaiterTests.swift
+++ b/Tests/SotoCoreTests/WaiterTests.swift
@@ -19,44 +19,104 @@ import SotoTestUtils
 import XCTest
 
 class WaiterTests: XCTestCase {
-    func testBasicWaiter() {
-        let awsServer = AWSTestServer(serviceProtocol: .json)
-        let config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
-        let client = createAWSClient(credentialProvider: .empty, middlewares: [AWSLoggingMiddleware()])
-        defer {
-            XCTAssertNoThrow(try client.syncShutdown())
-            XCTAssertNoThrow(try awsServer.stop())
-        }
+    static var awsServer: AWSTestServer!
+    static var config: AWSServiceConfig!
+    static var client: AWSClient!
 
-        struct Input: AWSEncodableShape & Decodable {
-            let i: Int
-        }
-        struct Output: AWSDecodableShape & Encodable {
-            let i: Int
-        }
-        func operation(input: Input, logger: Logger, eventLoop: EventLoop?) -> EventLoopFuture<Output> {
-            client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: logger, on: eventLoop)
-        }
+    class override func setUp() {
+        Self.awsServer = AWSTestServer(serviceProtocol: .json)
+        Self.config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
+        Self.client = createAWSClient(credentialProvider: .empty, middlewares: [AWSLoggingMiddleware()])
+    }
+
+    class override func tearDown() {
+        XCTAssertNoThrow(try client.syncShutdown())
+        XCTAssertNoThrow(try awsServer.stop())
+    }
+
+    struct Input: AWSEncodableShape & Decodable {
+        let i: Int
+    }
+    struct Output: AWSDecodableShape & Encodable {
+        let i: Int
+    }
+    func operation(input: Input, logger: Logger, eventLoop: EventLoop?) -> EventLoopFuture<Output> {
+        Self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: Self.config, input: input, logger: logger, on: eventLoop)
+    }
+
+    func testBasicWaiter() {
         let waiter = AWSClient.Waiter(
-            acceptors: [.init(state: .success, matcher: AWSOutputMatcher(path: \Output.i, expected: 3))],
-            maxRetryAttempts: 20,
+            acceptors: [
+                .init(state: .success, matcher: AWSOutputMatcher(path: \Output.i, expected: 3))
+            ],
+            minDelayTime: .seconds(2),
+            maxDelayTime: .seconds(4),
             command: operation
         )
-        do {
-            let input = Input(i: 1)
-            let response = client.wait(input, waiter: waiter, maxWaitTime: .seconds(20), logger: TestEnvironment.logger)
+        let input = Input(i: 1)
+        let response = Self.client.wait(input, waiter: waiter, logger: TestEnvironment.logger)
 
-            var i = 0
-            try awsServer.process { (request: Input) -> AWSTestServer.Result<Output> in
-                //let receivedInput = try JSONDecoder().decode(Input.self, from: request.body)
-                i += 1
-                return .result(Output(i: i), continueProcessing: i < 3)
+        var i = 0
+        XCTAssertNoThrow(try Self.awsServer.process { (request: Input) -> AWSTestServer.Result<Output> in
+            i += 1
+            return .result(Output(i: i), continueProcessing: i < 3)
+        })
+
+        XCTAssertNoThrow(try response.wait())
+    }
+
+    func testTimeoutWaiter() {
+        let waiter = AWSClient.Waiter(
+            acceptors: [
+                .init(state: .success, matcher: AWSOutputMatcher(path: \Output.i, expected: 3))
+            ],
+            minDelayTime: .seconds(2),
+            maxDelayTime: .seconds(4),
+            command: operation
+        )
+        let input = Input(i: 1)
+        let response = Self.client.wait(input, waiter: waiter, maxWaitTime: .seconds(4), logger: TestEnvironment.logger)
+
+        var i = 0
+        XCTAssertNoThrow(try Self.awsServer.process { (request: Input) -> AWSTestServer.Result<Output> in
+            i += 1
+            return .result(Output(i: i), continueProcessing: i < 2)
+        })
+
+        XCTAssertThrowsError(try response.wait()) { error in
+            switch error {
+            case let error as AWSClient.ClientError where error == .waiterTimeout:
+                break
+            default:
+                XCTFail("\(error)")
             }
-
-            try response.wait()
-        } catch {
-            XCTFail("Unexpected error: \(error)")
         }
+    }
+
+    func testErrorWaiter() {
+        let waiter = AWSClient.Waiter(
+            acceptors: [
+                .init(state: .retry, matcher: AWSErrorMatcher(AWSClientError.accessDenied)),
+                .init(state: .success, matcher: AWSOutputMatcher(path: \Output.i, expected: 3))
+            ],
+            minDelayTime: .seconds(2),
+            maxDelayTime: .seconds(4),
+            command: operation
+        )
+        let input = Input(i: 1)
+        let response = Self.client.wait(input, waiter: waiter, logger: TestEnvironment.logger)
+
+        var i = 0
+        XCTAssertNoThrow(try Self.awsServer.process { (request: Input) -> AWSTestServer.Result<Output> in
+            i += 1
+            if i < 3 {
+                return .error(.accessDenied, continueProcessing: true)
+            } else {
+                return .result(Output(i: i), continueProcessing: false)
+            }
+        })
+
+        XCTAssertNoThrow(try response.wait())
     }
 
 }

--- a/Tests/SotoCoreTests/WaiterTests.swift
+++ b/Tests/SotoCoreTests/WaiterTests.swift
@@ -96,7 +96,7 @@ class WaiterTests: XCTestCase {
     func testErrorWaiter() {
         let waiter = AWSClient.Waiter(
             acceptors: [
-                .init(state: .retry, matcher: AWSErrorMatcher(AWSClientError.accessDenied)),
+                .init(state: .retry, matcher: AWSErrorCodeMatcher("AccessDenied")),
                 .init(state: .success, matcher: AWSPathMatcher(path: \Output.i, expected: 3))
             ],
             minDelayTime: .seconds(2),

--- a/Tests/SotoCoreTests/WaiterTests.swift
+++ b/Tests/SotoCoreTests/WaiterTests.swift
@@ -34,9 +34,7 @@ class WaiterTests: XCTestCase {
         XCTAssertNoThrow(try self.awsServer.stop())
     }
 
-    struct Input: AWSEncodableShape & Decodable {
-        let i: Int
-    }
+    struct Input: AWSEncodableShape & Decodable {}
 
     struct Output: AWSDecodableShape & Encodable {
         let i: Int
@@ -46,7 +44,20 @@ class WaiterTests: XCTestCase {
         Self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: Self.config, input: input, logger: logger, on: eventLoop)
     }
 
-    func testBasicWaiter() {
+    struct ArrayOutput: AWSDecodableShape & Encodable {
+        struct Element: AWSDecodableShape & Encodable, ExpressibleByBooleanLiteral {
+            let status: Bool
+            init(booleanLiteral: Bool) {
+                self.status = booleanLiteral
+            }
+        }
+        let array: [Element]
+    }
+    func arrayOperation(input: Input, logger: Logger, eventLoop: EventLoop?) -> EventLoopFuture<ArrayOutput> {
+        Self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: Self.config, input: input, logger: logger, on: eventLoop)
+    }
+
+    func testPathWaiter() {
         let waiter = AWSClient.Waiter(
             acceptors: [
                 .init(state: .success, matcher: AWSPathMatcher(path: \Output.i, expected: 3)),
@@ -55,13 +66,63 @@ class WaiterTests: XCTestCase {
             maxDelayTime: .seconds(4),
             command: self.operation
         )
-        let input = Input(i: 1)
+        let input = Input()
         let response = Self.client.wait(input, waiter: waiter, logger: TestEnvironment.logger)
 
         var i = 0
         XCTAssertNoThrow(try Self.awsServer.process { (_: Input) -> AWSTestServer.Result<Output> in
             i += 1
             return .result(Output(i: i), continueProcessing: i < 3)
+        })
+
+        XCTAssertNoThrow(try response.wait())
+    }
+
+    func testAnyPathWaiter() {
+        let waiter = AWSClient.Waiter(
+            acceptors: [
+                .init(state: .success, matcher: AWSAnyPathMatcher(arrayPath: \ArrayOutput.array, elementPath: \ArrayOutput.Element.status, expected: true)),
+            ],
+            minDelayTime: .seconds(2),
+            maxDelayTime: .seconds(4),
+            command: self.arrayOperation
+        )
+        let input = Input()
+        let response = Self.client.wait(input, waiter: waiter, logger: TestEnvironment.logger)
+
+        var i = 0
+        XCTAssertNoThrow(try Self.awsServer.process { (_: Input) -> AWSTestServer.Result<ArrayOutput> in
+            i += 1
+            if i < 2 {
+                return .result(ArrayOutput(array: [false, false, false]), continueProcessing: true)
+            } else {
+                return .result(ArrayOutput(array: [false, true, false]), continueProcessing: false)
+            }
+        })
+
+        XCTAssertNoThrow(try response.wait())
+    }
+
+    func testAllPathWaiter() {
+        let waiter = AWSClient.Waiter(
+            acceptors: [
+                .init(state: .success, matcher: AWSAllPathMatcher(arrayPath: \ArrayOutput.array, elementPath: \ArrayOutput.Element.status, expected: true)),
+            ],
+            minDelayTime: .seconds(2),
+            maxDelayTime: .seconds(4),
+            command: self.arrayOperation
+        )
+        let input = Input()
+        let response = Self.client.wait(input, waiter: waiter, logger: TestEnvironment.logger)
+
+        var i = 0
+        XCTAssertNoThrow(try Self.awsServer.process { (_: Input) -> AWSTestServer.Result<ArrayOutput> in
+            i += 1
+            if i < 2 {
+                return .result(ArrayOutput(array: [false, true, false]), continueProcessing: true)
+            } else {
+                return .result(ArrayOutput(array: [true, true, true]), continueProcessing: false)
+            }
         })
 
         XCTAssertNoThrow(try response.wait())
@@ -76,7 +137,7 @@ class WaiterTests: XCTestCase {
             maxDelayTime: .seconds(4),
             command: self.operation
         )
-        let input = Input(i: 1)
+        let input = Input()
         let response = Self.client.wait(input, waiter: waiter, maxWaitTime: .seconds(4), logger: TestEnvironment.logger)
 
         var i = 0
@@ -105,7 +166,7 @@ class WaiterTests: XCTestCase {
             maxDelayTime: .seconds(4),
             command: self.operation
         )
-        let input = Input(i: 1)
+        let input = Input()
         let response = Self.client.wait(input, waiter: waiter, logger: TestEnvironment.logger)
 
         var i = 0
@@ -131,7 +192,7 @@ class WaiterTests: XCTestCase {
             maxDelayTime: .seconds(4),
             command: self.operation
         )
-        let input = Input(i: 1)
+        let input = Input()
         let response = Self.client.wait(input, waiter: waiter, logger: TestEnvironment.logger)
 
         var i = 0

--- a/Tests/SotoCoreTests/WaiterTests.swift
+++ b/Tests/SotoCoreTests/WaiterTests.swift
@@ -14,7 +14,7 @@
 
 import AsyncHTTPClient
 import NIO
-@testable import SotoCore
+import SotoCore
 import SotoTestUtils
 import XCTest
 

--- a/Tests/SotoCoreTests/WaiterTests.swift
+++ b/Tests/SotoCoreTests/WaiterTests.swift
@@ -19,17 +19,17 @@ import SotoTestUtils
 import XCTest
 
 class WaiterTests: XCTestCase {
-    static var awsServer: AWSTestServer!
-    static var config: AWSServiceConfig!
-    static var client: AWSClient!
+    var awsServer: AWSTestServer!
+    var config: AWSServiceConfig!
+    var client: AWSClient!
 
-    override class func setUp() {
-        Self.awsServer = AWSTestServer(serviceProtocol: .json)
-        Self.config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: self.awsServer.address)
-        Self.client = createAWSClient(credentialProvider: .empty, middlewares: [AWSLoggingMiddleware()])
+    override func setUp() {
+        self.awsServer = AWSTestServer(serviceProtocol: .json)
+        self.config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: self.awsServer.address)
+        self.client = createAWSClient(credentialProvider: .empty, middlewares: [AWSLoggingMiddleware()])
     }
 
-    override class func tearDown() {
+    override func tearDown() {
         XCTAssertNoThrow(try self.client.syncShutdown())
         XCTAssertNoThrow(try self.awsServer.stop())
     }
@@ -41,7 +41,7 @@ class WaiterTests: XCTestCase {
     }
 
     func operation(input: Input, logger: Logger, eventLoop: EventLoop?) -> EventLoopFuture<Output> {
-        Self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: Self.config, input: input, logger: logger, on: eventLoop)
+        self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
     }
 
     struct ArrayOutput: AWSDecodableShape & Encodable {
@@ -60,7 +60,7 @@ class WaiterTests: XCTestCase {
     }
 
     func arrayOperation(input: Input, logger: Logger, eventLoop: EventLoop?) -> EventLoopFuture<ArrayOutput> {
-        Self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: Self.config, input: input, logger: logger, on: eventLoop)
+        self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
     }
 
     struct OptionalArrayOutput: AWSDecodableShape & Encodable {
@@ -75,7 +75,7 @@ class WaiterTests: XCTestCase {
     }
 
     func optionalArrayOperation(input: Input, logger: Logger, eventLoop: EventLoop?) -> EventLoopFuture<OptionalArrayOutput> {
-        Self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: Self.config, input: input, logger: logger, on: eventLoop)
+        self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
     }
 
     func testJMESPathWaiter() {
@@ -87,10 +87,10 @@ class WaiterTests: XCTestCase {
             command: self.arrayOperation
         )
         let input = Input()
-        let response = Self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
+        let response = self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
 
         var i = 0
-        XCTAssertNoThrow(try Self.awsServer.process { (_: Input) -> AWSTestServer.Result<ArrayOutput> in
+        XCTAssertNoThrow(try self.awsServer.process { (_: Input) -> AWSTestServer.Result<ArrayOutput> in
             i += 1
             return .result(ArrayOutput(array: [.init(i >= 3), .init(i >= 2), .init(i >= 1)]), continueProcessing: i < 3)
         })
@@ -103,7 +103,7 @@ class WaiterTests: XCTestCase {
             let s: String
         }
         func operation(input: Input, logger: Logger, eventLoop: EventLoop?) -> EventLoopFuture<StringOutput> {
-            Self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: Self.config, input: input, logger: logger, on: eventLoop)
+            self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
         }
         let waiter = AWSClient.Waiter(
             acceptors: [
@@ -113,10 +113,10 @@ class WaiterTests: XCTestCase {
             command: operation
         )
         let input = Input()
-        let response = Self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
+        let response = self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
 
         var i = 0
-        XCTAssertNoThrow(try Self.awsServer.process { (_: Input) -> AWSTestServer.Result<StringOutput> in
+        XCTAssertNoThrow(try self.awsServer.process { (_: Input) -> AWSTestServer.Result<StringOutput> in
             i += 1
             if i < 2 {
                 return .result(.init(s: "no"), continueProcessing: true)
@@ -138,7 +138,7 @@ class WaiterTests: XCTestCase {
             let e: YesNo
         }
         func operation(input: Input, logger: Logger, eventLoop: EventLoop?) -> EventLoopFuture<EnumOutput> {
-            Self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: Self.config, input: input, logger: logger, on: eventLoop)
+            self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: self.config, input: input, logger: logger, on: eventLoop)
         }
         let waiter = AWSClient.Waiter(
             acceptors: [
@@ -148,10 +148,10 @@ class WaiterTests: XCTestCase {
             command: operation
         )
         let input = Input()
-        let response = Self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
+        let response = self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
 
         var i = 0
-        XCTAssertNoThrow(try Self.awsServer.process { (_: Input) -> AWSTestServer.Result<EnumOutput> in
+        XCTAssertNoThrow(try self.awsServer.process { (_: Input) -> AWSTestServer.Result<EnumOutput> in
             i += 1
             if i < 2 {
                 return .result(.init(e: .no), continueProcessing: true)
@@ -172,10 +172,10 @@ class WaiterTests: XCTestCase {
             command: self.arrayOperation
         )
         let input = Input()
-        let response = Self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
+        let response = self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
 
         var i = 0
-        XCTAssertNoThrow(try Self.awsServer.process { (_: Input) -> AWSTestServer.Result<ArrayOutput> in
+        XCTAssertNoThrow(try self.awsServer.process { (_: Input) -> AWSTestServer.Result<ArrayOutput> in
             i += 1
             if i < 2 {
                 return .result(ArrayOutput(array: [false, false, false]), continueProcessing: true)
@@ -196,10 +196,10 @@ class WaiterTests: XCTestCase {
             command: self.arrayOperation
         )
         let input = Input()
-        let response = Self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
+        let response = self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
 
         var i = 0
-        XCTAssertNoThrow(try Self.awsServer.process { (_: Input) -> AWSTestServer.Result<ArrayOutput> in
+        XCTAssertNoThrow(try self.awsServer.process { (_: Input) -> AWSTestServer.Result<ArrayOutput> in
             i += 1
             if i < 2 {
                 return .result(ArrayOutput(array: [false, true, false]), continueProcessing: true)
@@ -223,7 +223,7 @@ class WaiterTests: XCTestCase {
         let config = createServiceConfig(serviceProtocol: .restxml, endpoint: awsServer.address)
 
         func arrayOperation(input: Input, logger: Logger, eventLoop: EventLoop?) -> EventLoopFuture<ArrayOutput> {
-            Self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: logger, on: eventLoop)
+            self.client.execute(operation: "Basic", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: logger, on: eventLoop)
         }
 
         let waiter = AWSClient.Waiter(
@@ -234,7 +234,7 @@ class WaiterTests: XCTestCase {
             command: arrayOperation
         )
         let input = Input(test: "Input")
-        let response = Self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
+        let response = self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
 
         var i = 0
         XCTAssertNoThrow(try awsServer.process { (_: Input) -> AWSTestServer.Result<ArrayOutput> in
@@ -255,10 +255,10 @@ class WaiterTests: XCTestCase {
             command: self.operation
         )
         let input = Input()
-        let response = Self.client.waitUntil(input, waiter: waiter, maxWaitTime: .seconds(4), logger: TestEnvironment.logger)
+        let response = self.client.waitUntil(input, waiter: waiter, maxWaitTime: .seconds(4), logger: TestEnvironment.logger)
 
         var i = 0
-        XCTAssertNoThrow(try Self.awsServer.process { (_: Input) -> AWSTestServer.Result<Output> in
+        XCTAssertNoThrow(try self.awsServer.process { (_: Input) -> AWSTestServer.Result<Output> in
             i += 1
             return .result(Output(i: i), continueProcessing: i < 2)
         })
@@ -283,10 +283,10 @@ class WaiterTests: XCTestCase {
             command: self.operation
         )
         let input = Input()
-        let response = Self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
+        let response = self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
 
         var i = 0
-        XCTAssertNoThrow(try Self.awsServer.process { (_: Input) -> AWSTestServer.Result<Output> in
+        XCTAssertNoThrow(try self.awsServer.process { (_: Input) -> AWSTestServer.Result<Output> in
             i += 1
             if i < 3 {
                 return .error(.accessDenied, continueProcessing: true)
@@ -308,10 +308,10 @@ class WaiterTests: XCTestCase {
             command: self.operation
         )
         let input = Input()
-        let response = Self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
+        let response = self.client.waitUntil(input, waiter: waiter, logger: TestEnvironment.logger)
 
         var i = 0
-        XCTAssertNoThrow(try Self.awsServer.process { (_: Input) -> AWSTestServer.Result<Output> in
+        XCTAssertNoThrow(try self.awsServer.process { (_: Input) -> AWSTestServer.Result<Output> in
             i += 1
             if i < 3 {
                 return .error(.notFound, continueProcessing: true)


### PR DESCRIPTION
Waiters are a client-side abstraction used to poll a resource until a desired state is reached, or until it is determined that the resource will never enter into the desired state. This is a common task when working with services that are eventually consistent like Amazon S3 or services that asynchronously create resources like Amazon EC2. Writing logic to continuously poll the status of a resource can be cumbersome and error-prone. The goal of waiters is to move this responsibility out of customer code and onto Soto.

- Added `AWSClient.waitUntil` function which polls a resource until a matcher returns a positive
- Implemented various matchers. Include path (matching value using JMESPath), error status, error code, anyPath and allPath for multiple values returned by a path

See the Smithy spec for a more in-depth description of Waiters https://awslabs.github.io/smithy/1.0/spec/waiters.html