### PR TITLE
Add host prefix to AWSRequest

### DIFF
--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2020 the Soto project authors
+// Copyright (c) 2017-2021 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -265,6 +265,7 @@ extension AWSClient {
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
         input: Input,
+        hostPrefix: String? = nil,
         logger: Logger = AWSClient.loggingDisabled,
         on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Void> {
@@ -276,6 +277,7 @@ extension AWSClient {
                     path: path,
                     httpMethod: httpMethod,
                     input: input,
+                    hostPrefix: hostPrefix,
                     configuration: serviceConfig
                 )
             },
@@ -385,6 +387,7 @@ extension AWSClient {
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
         input: Input,
+        hostPrefix: String? = nil,
         logger: Logger = AWSClient.loggingDisabled,
         on eventLoop: EventLoop? = nil
     ) -> EventLoopFuture<Output> {
@@ -396,6 +399,7 @@ extension AWSClient {
                     path: path,
                     httpMethod: httpMethod,
                     input: input,
+                    hostPrefix: hostPrefix,
                     configuration: serviceConfig
                 )
             },
@@ -427,6 +431,7 @@ extension AWSClient {
         httpMethod: HTTPMethod,
         serviceConfig: AWSServiceConfig,
         input: Input,
+        hostPrefix: String? = nil,
         logger: Logger = AWSClient.loggingDisabled,
         on eventLoop: EventLoop? = nil,
         stream: @escaping AWSHTTPClient.ResponseStream
@@ -439,6 +444,7 @@ extension AWSClient {
                     path: path,
                     httpMethod: httpMethod,
                     input: input,
+                    hostPrefix: hostPrefix,
                     configuration: serviceConfig
                 )
             },

--- a/Sources/SotoCore/Doc/AWSShape.swift
+++ b/Sources/SotoCore/Doc/AWSShape.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2020 the Soto project authors
+// Copyright (c) 2017-2021 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -21,11 +21,16 @@ import struct Foundation.UUID
 public protocol AWSShape {
     /// The array of members serialization helpers
     static var _encoding: [AWSMemberEncoding] { get }
+    static var _hostPrefix: String? { get }
 }
 
 extension AWSShape {
     public static var _encoding: [AWSMemberEncoding] {
         return []
+    }
+
+    public static var _hostPrefix: String? {
+        nil
     }
 
     /// return member with provided name

--- a/Sources/SotoCore/Doc/AWSShape.swift
+++ b/Sources/SotoCore/Doc/AWSShape.swift
@@ -21,16 +21,11 @@ import struct Foundation.UUID
 public protocol AWSShape {
     /// The array of members serialization helpers
     static var _encoding: [AWSMemberEncoding] { get }
-    static var _hostPrefix: String? { get }
 }
 
 extension AWSShape {
     public static var _encoding: [AWSMemberEncoding] {
         return []
-    }
-
-    public static var _hostPrefix: String? {
-        nil
     }
 
     /// return member with provided name

--- a/Sources/SotoCore/Message/AWSRequest.swift
+++ b/Sources/SotoCore/Message/AWSRequest.swift
@@ -120,11 +120,12 @@ extension AWSRequest {
         path: String,
         httpMethod: HTTPMethod,
         input: Input,
+        hostPrefix: String? = nil,
         configuration: AWSServiceConfig
     ) throws {
         var headers = HTTPHeaders()
         var path = path
-        var hostPrefix = Input._hostPrefix
+        var hostPrefix = hostPrefix
         var body: Body = .empty
         var queryParams: [(key: String, value: Any)] = []
 

--- a/Sources/SotoCore/Message/AWSRequest.swift
+++ b/Sources/SotoCore/Message/AWSRequest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2020 the Soto project authors
+// Copyright (c) 2017-2021 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -124,6 +124,7 @@ extension AWSRequest {
     ) throws {
         var headers = HTTPHeaders()
         var path = path
+        var hostPrefix = Input._hostPrefix
         var body: Body = .empty
         var queryParams: [(key: String, value: Any)] = []
 
@@ -169,7 +170,8 @@ extension AWSRequest {
                     path = path
                         .replacingOccurrences(of: "{\(location)}", with: Self.urlEncodePathComponent(String(describing: value)))
                         .replacingOccurrences(of: "{\(location)+}", with: Self.urlEncodePath(String(describing: value)))
-
+                    hostPrefix = hostPrefix?
+                        .replacingOccurrences(of: "{\(location)}", with: Self.urlEncodePathComponent(String(describing: value)))
                 default:
                     memberVariablesCount += 1
                 }
@@ -244,6 +246,10 @@ extension AWSRequest {
 
         guard var urlComponents = URLComponents(string: "\(configuration.endpoint)\(path)") else {
             throw AWSClient.ClientError.invalidURL
+        }
+
+        if let hostPrefix = hostPrefix, let host = urlComponents.host {
+            urlComponents.host = hostPrefix + host
         }
 
         // add queries from the parsed path to the query params list

--- a/Tests/SotoCoreTests/AWSRequestTests.swift
+++ b/Tests/SotoCoreTests/AWSRequestTests.swift
@@ -363,20 +363,24 @@ class AWSRequestTests: XCTestCase {
 
     /// Test host prefix
     func testHostPrefix() {
-        struct Input: AWSEncodableShape {
-            static let _hostPrefix: String? = "foo."
-        }
+        struct Input: AWSEncodableShape {}
         let input = Input()
         let config = createServiceConfig(serviceProtocol: .json(version: "1.0"), endpoint: "https://test.com")
         var request: AWSRequest?
-        XCTAssertNoThrow(request = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: input, configuration: config))
+        XCTAssertNoThrow(request = try AWSRequest(
+            operation: "Test",
+            path: "/",
+            httpMethod: .POST,
+            input: input,
+            hostPrefix: "foo.",
+            configuration: config
+        ))
         XCTAssertEqual(request?.url.absoluteString, "https://foo.test.com/")
     }
 
     /// Test host prefix
     func testHostPrefixLabel() {
         struct Input: AWSEncodableShape {
-            static let _hostPrefix: String? = "{AccountId}."
             static let _encoding: [AWSMemberEncoding] = [
                 .init(label: "accountId", location: .uri(locationName: "AccountId")),
             ]
@@ -385,7 +389,14 @@ class AWSRequestTests: XCTestCase {
         let input = Input(accountId: "12345678")
         let config = createServiceConfig(serviceProtocol: .json(version: "1.0"), endpoint: "https://test.com")
         var request: AWSRequest?
-        XCTAssertNoThrow(request = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: input, configuration: config))
+        XCTAssertNoThrow(request = try AWSRequest(
+            operation: "Test",
+            path: "/",
+            httpMethod: .POST,
+            input: input,
+            hostPrefix: "{AccountId}.",
+            configuration: config
+        ))
         XCTAssertEqual(request?.url.absoluteString, "https://12345678.test.com/")
     }
 }

--- a/Tests/SotoCoreTests/AWSRequestTests.swift
+++ b/Tests/SotoCoreTests/AWSRequestTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2020 the Soto project authors
+// Copyright (c) 2017-2021 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -359,5 +359,33 @@ class AWSRequestTests: XCTestCase {
         var request: AWSRequest?
         XCTAssertNoThrow(request = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: input, configuration: config))
         XCTAssertEqual(request?.body.asString(), "{}")
+    }
+
+    /// Test host prefix
+    func testHostPrefix() {
+        struct Input: AWSEncodableShape {
+            static let _hostPrefix: String? = "foo."
+        }
+        let input = Input()
+        let config = createServiceConfig(serviceProtocol: .json(version: "1.0"), endpoint: "https://test.com")
+        var request: AWSRequest?
+        XCTAssertNoThrow(request = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: input, configuration: config))
+        XCTAssertEqual(request?.url.absoluteString, "https://foo.test.com/")
+    }
+
+    /// Test host prefix
+    func testHostPrefixLabel() {
+        struct Input: AWSEncodableShape {
+            static let _hostPrefix: String? = "{AccountId}."
+            static let _encoding: [AWSMemberEncoding] = [
+                .init(label: "accountId", location: .uri(locationName: "AccountId")),
+            ]
+            let accountId: String
+        }
+        let input = Input(accountId: "12345678")
+        let config = createServiceConfig(serviceProtocol: .json(version: "1.0"), endpoint: "https://test.com")
+        var request: AWSRequest?
+        XCTAssertNoThrow(request = try AWSRequest(operation: "Test", path: "/", httpMethod: .POST, input: input, configuration: config))
+        XCTAssertEqual(request?.url.absoluteString, "https://12345678.test.com/")
     }
 }


### PR DESCRIPTION
A number of services have API calls that add a prefix to the host name (chime, location, s3control etc). This PR implements this by adding an optional `hostPrefix` parameter to all the `AWSClient.execute` functions. If set it prepends this value to the hostname. It is also possible to have input shape members affect this prefix. See `S3Control` that prepends the hostname with the account number of the user.

See related Soto PR https://github.com/soto-project/soto/pull/507