### PR TITLE
Stream writer

### DIFF
--- a/Sources/SotoCore/AWSShapes/Payload.swift
+++ b/Sources/SotoCore/AWSShapes/Payload.swift
@@ -139,6 +139,11 @@ public struct AWSPayload {
         return AWSPayload(payload: .stream(reader))
     }
 
+    /// construct a payload from a stream reader object.
+    internal static func streamWriter(_ writer: StreamWriter) -> Self {
+        return AWSPayload(payload: .streamWriter(writer))
+    }
+
     /// Return the size of the payload. If the payload is a stream it is always possible to return a size
     public var size: Int? {
         switch payload {

--- a/Sources/SotoCore/AWSShapes/Payload.swift
+++ b/Sources/SotoCore/AWSShapes/Payload.swift
@@ -23,7 +23,7 @@ public struct AWSPayload {
     enum Payload {
         case byteBuffer(ByteBuffer)
         case stream(StreamReader)
-        case streamWriter(StreamWriter)
+        case streamWriter(StreamWriterProtocol)
         case empty
     }
 
@@ -44,7 +44,7 @@ public struct AWSPayload {
         return AWSPayload(payload: .stream(ChunkedStreamReader(size: size, read: stream, byteBufferAllocator: byteBufferAllocator)))
     }
 
-    public static func streamWriter(_ writer: ChunkedStreamWriter) -> Self {
+    public static func streamWriter(_ writer: AWSStreamWriter) -> Self {
         return AWSPayload(payload: .streamWriter(writer))
     }
 
@@ -140,7 +140,7 @@ public struct AWSPayload {
     }
 
     /// construct a payload from a stream reader object.
-    internal static func streamWriter(_ writer: StreamWriter) -> Self {
+    internal static func streamWriter(_ writer: StreamWriterProtocol) -> Self {
         return AWSPayload(payload: .streamWriter(writer))
     }
 

--- a/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
@@ -37,6 +37,13 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
             requestBody = .stream(length: reader.contentSize) { writer in
                 return writer.write(reader: reader, on: eventLoop)
             }
+        case .streamWriter(let streamWriter):
+            requestHeaders = streamWriter.updateHeaders(headers: requestHeaders)
+            requestBody = .stream(length: streamWriter.length) { writer in
+                streamWriter.setParentWriter(writer)
+                return streamWriter.finishedPromise.futureResult
+            }
+
         case .empty:
             requestBody = nil
         }

--- a/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
@@ -40,7 +40,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
         case .streamWriter(let streamWriter):
             requestHeaders = streamWriter.updateHeaders(headers: requestHeaders)
             requestBody = .stream(length: streamWriter.length) { writer in
-                streamWriter.setParentWriter(writer)
+                streamWriter.setChildWriter(writer)
                 return streamWriter.finishedPromise.futureResult
             }
 

--- a/Sources/SotoCore/HTTP/S3StreamWriter.swift
+++ b/Sources/SotoCore/HTTP/S3StreamWriter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2020 the Soto project authors
+// Copyright (c) 2017-2021 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -63,12 +63,12 @@ class S3StreamWriter: StreamWriterProtocol {
         self.tailBuffer.writeString("\r\n")
     }
 
-    /// Update HTTP headers. Add "Content-encoding" header. The "x-amz-decoded-content-length" header is added earlier in AWSRequest when
+    /// Update HTTP headers. Add "content-encoding" header. The "x-amz-decoded-content-length" header is added earlier in AWSRequest when
     /// initiating the signing process
     /// - Parameter headers: headers to update
     func updateHeaders(headers: HTTPHeaders) -> HTTPHeaders {
         var headers = headers
-        headers.add(name: "Content-Encoding", value: "aws-chunked")
+        headers.add(name: "content-encoding", value: "aws-chunked")
         return headers
     }
 

--- a/Sources/SotoCore/HTTP/S3StreamWriter.swift
+++ b/Sources/SotoCore/HTTP/S3StreamWriter.swift
@@ -101,7 +101,6 @@ class S3StreamWriter: StreamWriter {
             // write empty buffer
             _ = writeSignedBuffer(self.workingBuffer, to: writer)
             
-            assert(self.bytesWritten == self.length)
             self.finishedPromise.succeed(())
             // write end
             return writer.write(result, on: self.eventLoop)

--- a/Sources/SotoCore/HTTP/S3StreamWriter.swift
+++ b/Sources/SotoCore/HTTP/S3StreamWriter.swift
@@ -15,7 +15,7 @@
 import NIO
 import SotoSignerV4
 
-class S3StreamWriter: StreamWriter {
+class S3StreamWriter: StreamWriterProtocol {
     /// Working buffer size
     static let bufferSize: Int = 64 * 1024
     static let bufferSizeInHex = String(bufferSize, radix: 16)

--- a/Sources/SotoCore/HTTP/S3StreamWriter.swift
+++ b/Sources/SotoCore/HTTP/S3StreamWriter.swift
@@ -1,0 +1,141 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2020 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+import SotoSignerV4
+
+class S3StreamWriter: StreamWriter {
+    /// Working buffer size
+    static let bufferSize: Int = 64 * 1024
+    static let bufferSizeInHex = String(bufferSize, radix: 16)
+    static let bufferSizeLength = bufferSizeInHex.count
+    static let chunkSignatureLength = 1 + 16 + 64 // ";" + "chunk-signature=" + hex(sha256)
+    static let endOfLineLength = 2
+    /// Maximum size of chunk header
+    static let maxHeaderSize: Int = bufferSizeInHex.count + chunkSignatureLength + endOfLineLength
+
+    let length: Int
+    var bytesWritten: Int
+    let eventLoop: EventLoop
+    let writerPromise: EventLoopPromise<ChildStreamWriter>
+    let finishedPromise: EventLoopPromise<Void>
+
+    /// bytebuffer allocator
+    var byteBufferAllocator: ByteBufferAllocator
+
+    var signer: AWSSigner
+    var signingData: AWSSigner.ChunkedSigningData
+    var headerBuffer: ByteBuffer
+    var workingBuffer: ByteBuffer
+    var tailBuffer: ByteBuffer
+
+    init(
+        length: Int,
+        signer: AWSSigner,
+        seedSigningData: AWSSigner.ChunkedSigningData,
+        byteBufferAllocator: ByteBufferAllocator,
+        eventLoop: EventLoop
+    ) {
+        self.length = Self.calculateLength(from: length)
+        self.bytesWritten = 0
+        self.eventLoop = eventLoop
+        self.writerPromise = eventLoop.makePromise()
+        self.finishedPromise = eventLoop.makePromise()
+        
+        self.signer = signer
+        self.signingData = seedSigningData
+        // have separate buffers so we aren't allocating 128k
+        self.byteBufferAllocator = byteBufferAllocator
+        self.headerBuffer = byteBufferAllocator.buffer(capacity: Self.maxHeaderSize)
+        self.workingBuffer = byteBufferAllocator.buffer(capacity: Self.bufferSize)
+        self.tailBuffer = byteBufferAllocator.buffer(capacity: Self.endOfLineLength)
+        self.tailBuffer.writeString("\r\n")
+    }
+
+    /// Update HTTP headers. Add "Content-encoding" header. The "x-amz-decoded-content-length" header is added earlier in AWSRequest when
+    /// initiating the signing process
+    /// - Parameter headers: headers to update
+    func updateHeaders(headers: HTTPHeaders) -> HTTPHeaders {
+        var headers = headers
+        headers.add(name: "Content-Encoding", value: "aws-chunked")
+        return headers
+    }
+
+    func write(_ result: StreamWriterResult, to writer: ChildStreamWriter) -> EventLoopFuture<Void> {
+        switch result {
+        case .byteBuffer(var buffer):
+            let bytesRequired = Self.bufferSize - self.workingBuffer.readableBytes
+            guard var slice = buffer.readSlice(length: bytesRequired) else {
+                self.workingBuffer.writeBuffer(&buffer)
+                return eventLoop.makeSucceededVoidFuture()
+            }
+            self.workingBuffer.writeBuffer(&slice)
+            var writeResult = writeSignedBuffer(self.workingBuffer, to: writer)
+            self.workingBuffer.clear()
+            
+            while var slice = buffer.readSlice(length: Self.bufferSize) {
+                self.workingBuffer.writeBuffer(&slice)
+                writeResult = writeSignedBuffer(self.workingBuffer, to: writer)
+                self.workingBuffer.clear()
+            }
+            
+            self.workingBuffer.writeBuffer(&buffer)
+            return writeResult
+        case .end:
+            // if working buffer still has data write it out
+            if self.workingBuffer.readableBytes > 0 {
+                _ = writeSignedBuffer(self.workingBuffer, to: writer)
+                self.workingBuffer.clear()
+            }
+            // write empty buffer
+            _ = writeSignedBuffer(self.workingBuffer, to: writer)
+            
+            assert(self.bytesWritten == self.length)
+            self.finishedPromise.succeed(())
+            // write end
+            return writer.write(result, on: self.eventLoop)
+        }
+    }
+    
+    func writeSignedBuffer(_ buffer: ByteBuffer, to writer: ChildStreamWriter) -> EventLoopFuture<Void> {
+        // sign header etc
+        assert(buffer.readableBytes <= Self.bufferSize)
+        self.signingData = self.signer.signChunk(body: .byteBuffer(buffer), signingData: self.signingData)
+        let header = "\(String(buffer.readableBytes, radix: 16));chunk-signature=\(self.signingData.signature)\r\n"
+        self.headerBuffer.clear()
+        self.headerBuffer.writeString(header)
+        
+        self.bytesWritten += self.headerBuffer.readableBytes + buffer.readableBytes + self.tailBuffer.readableBytes
+        
+        writer.write(.byteBuffer(self.headerBuffer), on: self.eventLoop)
+        writer.write(.byteBuffer(buffer), on: self.eventLoop)
+        return writer.write(.byteBuffer(tailBuffer), on: self.eventLoop)
+    }
+
+    /// Calculate content size for aws chunked data.
+    static func calculateLength(from length: Int) -> Int {
+        let numberOfChunks = length / Self.bufferSize
+        let remainingBytes = length - numberOfChunks * Self.bufferSize
+        let lastChunkSize: Int
+        if remainingBytes > 0 {
+            lastChunkSize = remainingBytes + String(remainingBytes, radix: 16).count + Self.chunkSignatureLength + Self.endOfLineLength * 2
+        } else {
+            lastChunkSize = 0
+        }
+        let fullSize = numberOfChunks * (Self.bufferSize + Self.maxHeaderSize + Self.endOfLineLength) // number of chunks * chunk size
+            + lastChunkSize // last chunk size
+            + 1 + Self.chunkSignatureLength + Self.endOfLineLength * 2 // tail chunk size "(0;chunk-signature=hash)\r\n\r\n"
+        return fullSize
+    }
+}

--- a/Sources/SotoCore/HTTP/StreamWriter+write.swift
+++ b/Sources/SotoCore/HTTP/StreamWriter+write.swift
@@ -53,7 +53,7 @@ extension AsyncHTTPClient.HTTPClient.Body.StreamWriter {
 
                     // write all the chunks but the last.
                     byteBuffers.dropLast().forEach {
-                        _ = self.write(.byteBuffer($0))
+                        _ = self.write(IOData.byteBuffer($0))
                     }
                     if let lastBuffer = byteBuffers.last {
                         // store EventLoopFuture of last byteBuffer

--- a/Sources/SotoCore/HTTP/StreamWriter.swift
+++ b/Sources/SotoCore/HTTP/StreamWriter.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2020 the Soto project authors
+// Copyright (c) 2017-2021 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -103,13 +103,13 @@ public class AWSStreamWriter: StreamWriterProtocol {
         return futureResult
     }
 
-    /// Update headers. Add "Transfer-encoding" header if we don't have a steam size
+    /// Update headers. Add "transfer-encoding" header if we don't have a steam size
     /// - Parameter headers: headers to update
     func updateHeaders(headers: HTTPHeaders) -> HTTPHeaders {
         var headers = headers
         // add "Transfer-Encoding" header if streaming with unknown size
         if self.length == nil {
-            headers.add(name: "Transfer-Encoding", value: "chunked")
+            headers.add(name: "transfer-encoding", value: "chunked")
         }
         return headers
     }

--- a/Sources/SotoCore/HTTP/StreamWriter.swift
+++ b/Sources/SotoCore/HTTP/StreamWriter.swift
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2020 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import AsyncHTTPClient
+import NIO
+import NIOHTTP1
+
+/// Streaming result
+public enum StreamWriterResult {
+    case byteBuffer(ByteBuffer)
+    case end
+}
+
+protocol ParentStreamWriter {
+    /// write to stream
+    func write(_ result: StreamWriterResult)
+}
+
+/// Protocol for objects that supply streamed data to HTTPClient.Body.StreamWriter
+protocol StreamWriter: ParentStreamWriter {
+    var length: Int? { get }
+    /// Update headers for this kind of streamed data
+    /// - Parameter headers: headers to update
+    func updateHeaders(headers: HTTPHeaders) -> HTTPHeaders
+
+    func setParentWriter(_ writer: ParentStreamWriter)
+
+    var finishedPromise: EventLoopPromise<Void> { get }
+}
+
+extension StreamWriter {
+    func updateHeaders(headers: HTTPHeaders) -> HTTPHeaders { return headers }
+    var length: Int? { nil }
+    func setParentWriter(_ writer: StreamWriter) {}
+}
+
+extension AsyncHTTPClient.HTTPClient.Body.StreamWriter: ParentStreamWriter {
+    func write(_ result: StreamWriterResult) {
+        switch result {
+        case .byteBuffer(let buffer):
+            _ = self.write(IOData.byteBuffer(buffer))
+        case .end:
+            break
+        }
+    }
+}
+
+public class ChunkedStreamWriter: StreamWriter {
+    var length: Int?
+    var writerPromise: EventLoopPromise<ParentStreamWriter>
+    var finishedPromise: EventLoopPromise<Void>
+
+    init(length: Int? = nil, eventLoop: EventLoop) {
+        self.length = length
+        self.writerPromise = eventLoop.makePromise()
+        self.finishedPromise = eventLoop.makePromise()
+    }
+
+    func setParentWriter(_ writer: ParentStreamWriter) {
+        writerPromise.succeed(writer)
+    }
+    /// Update headers. Add "Transfer-encoding" header if we don't have a steam size
+    /// - Parameter headers: headers to update
+    func updateHeaders(headers: HTTPHeaders) -> HTTPHeaders {
+        var headers = headers
+        // add "Transfer-Encoding" header if streaming with unknown size
+        if self.length == nil {
+            headers.add(name: "Transfer-Encoding", value: "chunked")
+        }
+        return headers
+    }
+
+    public func write(_ result: StreamWriterResult) {
+        writerPromise.futureResult.whenSuccess { writer in
+            switch result {
+            case .byteBuffer(let buffer):
+                _ = writer.write(.byteBuffer(buffer))
+            case .end:
+                self.finishedPromise.succeed(())
+            }
+        }
+    }
+}

--- a/Sources/SotoCore/HTTP/StreamWriter.swift
+++ b/Sources/SotoCore/HTTP/StreamWriter.swift
@@ -22,54 +22,64 @@ public enum StreamWriterResult {
     case end
 }
 
-protocol ParentStreamWriter {
+protocol ChildStreamWriter {
     /// write to stream
-    func write(_ result: StreamWriterResult)
+    @discardableResult func write(_ result: StreamWriterResult, on eventLoop: EventLoop) -> EventLoopFuture<Void>
+}
+
+extension AsyncHTTPClient.HTTPClient.Body.StreamWriter: ChildStreamWriter {
+    func write(_ result: StreamWriterResult, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        switch result {
+        case .byteBuffer(let buffer):
+            return self.write(IOData.byteBuffer(buffer)).hop(to: eventLoop)
+        case .end:
+            return eventLoop.makeSucceededVoidFuture()
+        }
+    }
 }
 
 /// Protocol for objects that supply streamed data to HTTPClient.Body.StreamWriter
-protocol StreamWriter: ParentStreamWriter {
+protocol StreamWriter: ChildStreamWriter {
     var length: Int? { get }
+    var eventLoop: EventLoop { get }
+    var writerPromise: EventLoopPromise<ChildStreamWriter> { get }
+    var finishedPromise: EventLoopPromise<Void> { get }
     /// Update headers for this kind of streamed data
     /// - Parameter headers: headers to update
     func updateHeaders(headers: HTTPHeaders) -> HTTPHeaders
-
-    func setParentWriter(_ writer: ParentStreamWriter)
-
-    var finishedPromise: EventLoopPromise<Void> { get }
+    func write(_ result: StreamWriterResult, to: ChildStreamWriter) -> EventLoopFuture<Void>
 }
 
 extension StreamWriter {
+    @discardableResult public func write(_ result: StreamWriterResult) -> EventLoopFuture<Void> {
+        return write(result, on: eventLoop)
+    }
     func updateHeaders(headers: HTTPHeaders) -> HTTPHeaders { return headers }
     var length: Int? { nil }
-    func setParentWriter(_ writer: StreamWriter) {}
-}
+    func setChildWriter(_ writer: ChildStreamWriter) {
+        writerPromise.succeed(writer)
+    }
 
-extension AsyncHTTPClient.HTTPClient.Body.StreamWriter: ParentStreamWriter {
-    func write(_ result: StreamWriterResult) {
-        switch result {
-        case .byteBuffer(let buffer):
-            _ = self.write(IOData.byteBuffer(buffer))
-        case .end:
-            break
+    @discardableResult func write(_ result: StreamWriterResult, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        return writerPromise.futureResult.flatMap { writer in
+            write(result, to: writer)
         }
     }
 }
 
 public class ChunkedStreamWriter: StreamWriter {
-    var length: Int?
-    var writerPromise: EventLoopPromise<ParentStreamWriter>
-    var finishedPromise: EventLoopPromise<Void>
+    let length: Int?
+    let eventLoop: EventLoop
+    let writerPromise: EventLoopPromise<ChildStreamWriter>
+    let finishedPromise: EventLoopPromise<Void>
 
     init(length: Int? = nil, eventLoop: EventLoop) {
         self.length = length
+        self.eventLoop = eventLoop
         self.writerPromise = eventLoop.makePromise()
         self.finishedPromise = eventLoop.makePromise()
     }
 
-    func setParentWriter(_ writer: ParentStreamWriter) {
-        writerPromise.succeed(writer)
-    }
     /// Update headers. Add "Transfer-encoding" header if we don't have a steam size
     /// - Parameter headers: headers to update
     func updateHeaders(headers: HTTPHeaders) -> HTTPHeaders {
@@ -81,14 +91,13 @@ public class ChunkedStreamWriter: StreamWriter {
         return headers
     }
 
-    public func write(_ result: StreamWriterResult) {
-        writerPromise.futureResult.whenSuccess { writer in
-            switch result {
-            case .byteBuffer(let buffer):
-                _ = writer.write(.byteBuffer(buffer))
-            case .end:
-                self.finishedPromise.succeed(())
-            }
+    func write(_ result: StreamWriterResult, to writer: ChildStreamWriter) -> EventLoopFuture<Void> {
+        switch result {
+        case .byteBuffer(let buffer):
+            return writer.write(.byteBuffer(buffer), on: eventLoop).hop(to: eventLoop)
+        case .end:
+            self.finishedPromise.succeed(())
+            return eventLoop.makeSucceededVoidFuture()
         }
     }
 }

--- a/Sources/SotoCore/HTTP/StreamWriter.swift
+++ b/Sources/SotoCore/HTTP/StreamWriter.swift
@@ -22,11 +22,13 @@ public enum StreamWriterResult {
     case end
 }
 
+/// protocol for chaining stream writers together ending with the AsyncHTTPClient stream writer
 protocol ChildStreamWriter {
     /// write to stream
     @discardableResult func write(_ result: StreamWriterResult, on eventLoop: EventLoop) -> EventLoopFuture<Void>
 }
 
+/// extend so we can add to end of chain of stream writers
 extension AsyncHTTPClient.HTTPClient.Body.StreamWriter: ChildStreamWriter {
     func write(_ result: StreamWriterResult, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
         switch result {
@@ -39,27 +41,42 @@ extension AsyncHTTPClient.HTTPClient.Body.StreamWriter: ChildStreamWriter {
 }
 
 /// Protocol for objects that supply streamed data to HTTPClient.Body.StreamWriter
-protocol StreamWriter: ChildStreamWriter {
+protocol StreamWriterProtocol: ChildStreamWriter {
+    /// length of data to stream
     var length: Int? { get }
+    /// event loop to run stream writer on
     var eventLoop: EventLoop { get }
+    /// child writer promise
     var writerPromise: EventLoopPromise<ChildStreamWriter> { get }
+    /// finished streaming promise
     var finishedPromise: EventLoopPromise<Void> { get }
     /// Update headers for this kind of streamed data
     /// - Parameter headers: headers to update
     func updateHeaders(headers: HTTPHeaders) -> HTTPHeaders
+    /// Write result to child stream writer
+    /// - Parameters:
+    ///   - result: result to write
+    ///   - to: stream writer to write to
     func write(_ result: StreamWriterResult, to: ChildStreamWriter) -> EventLoopFuture<Void>
 }
 
-extension StreamWriter {
+extension StreamWriterProtocol {
+    /// Write to stream writer
+    /// - Parameter result: ByteBuffer or `.end`
+    /// - Returns: Returns when EventLoopFuture for when value has been written
     @discardableResult public func write(_ result: StreamWriterResult) -> EventLoopFuture<Void> {
         return write(result, on: eventLoop)
     }
+    /// Default implementation of updateHeaders returns the same headers back
     func updateHeaders(headers: HTTPHeaders) -> HTTPHeaders { return headers }
+    /// Default implementation of `length` returns nil
     var length: Int? { nil }
+    /// Set the child writer this steam writer should write to
     func setChildWriter(_ writer: ChildStreamWriter) {
         writerPromise.succeed(writer)
     }
 
+    /// Write value to StreamWriter
     @discardableResult func write(_ result: StreamWriterResult, on eventLoop: EventLoop) -> EventLoopFuture<Void> {
         return writerPromise.futureResult.flatMap { writer in
             write(result, to: writer)
@@ -67,7 +84,10 @@ extension StreamWriter {
     }
 }
 
-public class ChunkedStreamWriter: StreamWriter {
+/// Public stream writer class.
+///
+/// Forwards all values written to it to next stream writer in the chain ie it's child stream writer
+public class AWSStreamWriter: StreamWriterProtocol {
     let length: Int?
     let eventLoop: EventLoop
     let writerPromise: EventLoopPromise<ChildStreamWriter>

--- a/Sources/SotoCore/HTTP/StreamWriter.swift
+++ b/Sources/SotoCore/HTTP/StreamWriter.swift
@@ -65,8 +65,9 @@ extension StreamWriterProtocol {
     /// - Parameter result: ByteBuffer or `.end`
     /// - Returns: Returns when EventLoopFuture for when value has been written
     @discardableResult public func write(_ result: StreamWriterResult) -> EventLoopFuture<Void> {
-        return write(result, on: eventLoop)
+        return self.write(result, on: eventLoop).cascadeFailure(to: finishedPromise)
     }
+
     /// Default implementation of updateHeaders returns the same headers back
     func updateHeaders(headers: HTTPHeaders) -> HTTPHeaders { return headers }
     /// Default implementation of `length` returns nil
@@ -114,10 +115,10 @@ public class AWSStreamWriter: StreamWriterProtocol {
     func write(_ result: StreamWriterResult, to writer: ChildStreamWriter) -> EventLoopFuture<Void> {
         switch result {
         case .byteBuffer(let buffer):
-            return writer.write(.byteBuffer(buffer), on: eventLoop).hop(to: eventLoop)
+            return writer.write(.byteBuffer(buffer), on: self.eventLoop).hop(to: self.eventLoop)
         case .end:
             self.finishedPromise.succeed(())
-            return writer.write(result, on: eventLoop).hop(to: eventLoop)
+            return writer.write(result, on: self.eventLoop).hop(to: self.eventLoop)
         }
     }
 }

--- a/Sources/SotoCore/HTTP/StreamWriter.swift
+++ b/Sources/SotoCore/HTTP/StreamWriter.swift
@@ -97,7 +97,7 @@ public class ChunkedStreamWriter: StreamWriter {
             return writer.write(.byteBuffer(buffer), on: eventLoop).hop(to: eventLoop)
         case .end:
             self.finishedPromise.succeed(())
-            return eventLoop.makeSucceededVoidFuture()
+            return writer.write(result, on: eventLoop).hop(to: eventLoop)
         }
     }
 }

--- a/Sources/SotoCore/Message/AWSRequest.swift
+++ b/Sources/SotoCore/Message/AWSRequest.swift
@@ -72,6 +72,8 @@ public struct AWSRequest {
             } else {
                 bodyDataForSigning = .unsignedPayload
             }
+        case .streamWriter(_):
+            bodyDataForSigning = .unsignedPayload
         case .empty:
             bodyDataForSigning = nil
         }

--- a/Sources/SotoCore/Message/AWSRequest.swift
+++ b/Sources/SotoCore/Message/AWSRequest.swift
@@ -83,7 +83,7 @@ public struct AWSRequest {
                     length: writer.length!,
                     signer: signer,
                     seedSigningData: seedSigningData,
-                    byteBufferAllocator: ByteBufferAllocator(),
+                    byteBufferAllocator: byteBufferAllocator,
                     eventLoop: writer.eventLoop
                 )
                 writer.setChildWriter(s3Writer)

--- a/Tests/SotoCoreTests/AWSClientTests.swift
+++ b/Tests/SotoCoreTests/AWSClientTests.swift
@@ -299,7 +299,7 @@ class AWSClientTests: XCTestCase {
         var byteBuffer = ByteBufferAllocator().buffer(capacity: data.count)
         byteBuffer.writeBytes(data)
 
-        let stream = ChunkedStreamWriter(length: bufferSize, eventLoop: client.eventLoopGroup.next())
+        let stream = AWSStreamWriter(length: bufferSize, eventLoop: client.eventLoopGroup.next())
         let input = Input(payload: .streamWriter(stream))
         let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
         while byteBuffer.readableBytes > 0 {
@@ -417,7 +417,7 @@ class AWSClientTests: XCTestCase {
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
         defer { XCTAssertNoThrow(try elg.syncShutdownGracefully()) }
         // set up stream of 8 bytes but supply more than that
-        let stream = ChunkedStreamWriter(length: 8, eventLoop: elg.next())
+        let stream = AWSStreamWriter(length: 8, eventLoop: elg.next())
         stream.write(.byteBuffer(ByteBufferAllocator().buffer(string: "String longer than 8 bytes")))
         stream.write(.end)
         XCTAssertThrowsError(try self.testRequestStreamingWithPayload(.streamWriter(stream), eventLoopGroupProvider: .shared(elg))) { error in
@@ -432,7 +432,7 @@ class AWSClientTests: XCTestCase {
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 4)
         defer { XCTAssertNoThrow(try elg.syncShutdownGracefully()) }
         // set up stream of 8 bytes but supply more than that
-        let stream = ChunkedStreamWriter(length: 400, eventLoop: elg.next())
+        let stream = AWSStreamWriter(length: 400, eventLoop: elg.next())
         stream.write(.byteBuffer(ByteBufferAllocator().buffer(string: "String shorter than 400 bytes")))
         stream.write(.end)
         XCTAssertThrowsError(try self.testRequestStreamingWithPayload(.streamWriter(stream), eventLoopGroupProvider: .shared(elg))) { error in

--- a/Tests/SotoCoreTests/AWSClientTests.swift
+++ b/Tests/SotoCoreTests/AWSClientTests.swift
@@ -308,7 +308,7 @@ class AWSClientTests: XCTestCase {
             stream.write(.byteBuffer(buffer))
         }
         stream.write(.end)
-        
+
         try? server.processRaw { request in
             let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
             XCTAssertEqual(bytes, data)

--- a/Tests/SotoCoreTests/AWSClientTests.swift
+++ b/Tests/SotoCoreTests/AWSClientTests.swift
@@ -266,6 +266,53 @@ class AWSClientTests: XCTestCase {
         XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 18 * 1024, blockSize: 47 * 1024))
     }
 
+    func testRequestStreamWriter(config: AWSServiceConfig, client: AWSClient, server: AWSTestServer, bufferSize: Int, blockSize: Int) throws {
+        struct Input: AWSEncodableShape & AWSShapeWithPayload {
+            static var _payloadPath: String = "payload"
+            static var _payloadOptions: AWSShapePayloadOptions = [.allowStreaming, .raw]
+            let payload: AWSPayload
+            private enum CodingKeys: CodingKey {}
+        }
+        let data = createRandomBuffer(45, 9182, size: bufferSize)
+        var byteBuffer = ByteBufferAllocator().buffer(capacity: data.count)
+        byteBuffer.writeBytes(data)
+
+        let stream = ChunkedStreamWriter(length: bufferSize, eventLoop: client.eventLoopGroup.next())
+        let input = Input(payload: .streamWriter(stream))
+        let response = client.execute(operation: "test", path: "/", httpMethod: .POST, serviceConfig: config, input: input, logger: TestEnvironment.logger)
+        while byteBuffer.readableBytes > 0 {
+            let size = min(blockSize, byteBuffer.readableBytes)
+            let buffer = byteBuffer.readSlice(length: size)!
+            stream.write(.byteBuffer(buffer))
+        }
+        stream.write(.end)
+        
+        try? server.processRaw { request in
+            let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
+            XCTAssertEqual(bytes, data)
+            let response = AWSTestServer.Response(httpStatus: .ok, headers: [:], body: nil)
+            return .result(response)
+        }
+
+        try response.wait()
+    }
+
+    func testRequestStreamWriter() {
+        let awsServer = AWSTestServer(serviceProtocol: .json)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+        let config = createServiceConfig(endpoint: awsServer.address)
+        let client = createAWSClient(credentialProvider: .empty, httpClientProvider: .shared(httpClient))
+        defer {
+            XCTAssertNoThrow(try awsServer.stop())
+            XCTAssertNoThrow(try client.syncShutdown())
+            XCTAssertNoThrow(try httpClient.syncShutdown())
+        }
+
+        XCTAssertNoThrow(try self.testRequestStreamWriter(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: 16 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreamWriter(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: 17 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreamWriter(config: config, client: client, server: awsServer, bufferSize: 18 * 1024, blockSize: 47 * 1024))
+    }
+
     func testRequestS3Streaming() {
         let awsServer = AWSTestServer(serviceProtocol: .json)
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)

--- a/Tests/SotoCoreTests/AWSClientTests.swift
+++ b/Tests/SotoCoreTests/AWSClientTests.swift
@@ -266,6 +266,28 @@ class AWSClientTests: XCTestCase {
         XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 18 * 1024, blockSize: 47 * 1024))
     }
 
+    func testRequestS3Streaming() {
+        let awsServer = AWSTestServer(serviceProtocol: .json)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+        let config = createServiceConfig(service: "s3", endpoint: awsServer.address)
+        let client = createAWSClient(credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"), httpClientProvider: .shared(httpClient))
+        defer {
+            XCTAssertNoThrow(try client.syncShutdown())
+            XCTAssertNoThrow(try awsServer.stop())
+            XCTAssertNoThrow(try httpClient.syncShutdown())
+        }
+
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: 16 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 192 * 1024, blockSize: 128 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 81 * 1024, blockSize: 16 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: S3ChunkedStreamReader.bufferSize))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 130 * 1024, blockSize: S3ChunkedStreamReader.bufferSize))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: 17 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 68 * 1024, blockSize: 67 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 65537, blockSize: 65537))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 65552, blockSize: 65552))
+    }
+
     func testRequestStreamWriter(config: AWSServiceConfig, client: AWSClient, server: AWSTestServer, bufferSize: Int, blockSize: Int) throws {
         struct Input: AWSEncodableShape & AWSShapeWithPayload {
             static var _payloadPath: String = "payload"
@@ -313,26 +335,26 @@ class AWSClientTests: XCTestCase {
         XCTAssertNoThrow(try self.testRequestStreamWriter(config: config, client: client, server: awsServer, bufferSize: 18 * 1024, blockSize: 47 * 1024))
     }
 
-    func testRequestS3Streaming() {
+    func testRequestS3StreamWriter() {
         let awsServer = AWSTestServer(serviceProtocol: .json)
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
         let config = createServiceConfig(service: "s3", endpoint: awsServer.address)
         let client = createAWSClient(credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"), httpClientProvider: .shared(httpClient))
         defer {
-            XCTAssertNoThrow(try client.syncShutdown())
             XCTAssertNoThrow(try awsServer.stop())
+            XCTAssertNoThrow(try client.syncShutdown())
             XCTAssertNoThrow(try httpClient.syncShutdown())
         }
 
-        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: 16 * 1024))
-        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 192 * 1024, blockSize: 128 * 1024))
-        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 81 * 1024, blockSize: 16 * 1024))
-        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: S3ChunkedStreamReader.bufferSize))
-        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 130 * 1024, blockSize: S3ChunkedStreamReader.bufferSize))
-        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: 17 * 1024))
-        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 68 * 1024, blockSize: 67 * 1024))
-        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 65537, blockSize: 65537))
-        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 65552, blockSize: 65552))
+        XCTAssertNoThrow(try self.testRequestStreamWriter(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: 16 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreamWriter(config: config, client: client, server: awsServer, bufferSize: 192 * 1024, blockSize: 128 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreamWriter(config: config, client: client, server: awsServer, bufferSize: 81 * 1024, blockSize: 16 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreamWriter(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: S3ChunkedStreamReader.bufferSize))
+        XCTAssertNoThrow(try self.testRequestStreamWriter(config: config, client: client, server: awsServer, bufferSize: 130 * 1024, blockSize: S3ChunkedStreamReader.bufferSize))
+        XCTAssertNoThrow(try self.testRequestStreamWriter(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: 17 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreamWriter(config: config, client: client, server: awsServer, bufferSize: 68 * 1024, blockSize: 67 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreamWriter(config: config, client: client, server: awsServer, bufferSize: 65537, blockSize: 65537))
+        XCTAssertNoThrow(try self.testRequestStreamWriter(config: config, client: client, server: awsServer, bufferSize: 65552, blockSize: 65552))
     }
 
     func testRequestStreamingWithPayload(_ payload: AWSPayload) throws {


### PR DESCRIPTION
This introduces a new way to stream data into a request. Instead of asking the user for another buffer when needed via a callback a stream writer allows you to push data to a request when you want to. 
```swift
let streamWriter = AWSStreamWriter(length: 16384, on: eventLoop)
let futureResult = s3.putObject(body: .streamWriter(streamWriter), bucket: "mybucket", key: "mykey") 
streamWriter.write(.byteBuffer(buffer1))
streamWriter.write(.byteBuffer(buffer2))
streamWriter.write(.end)
try futureResult.wait()
```

In the example above we ignore the return value of `AWSStreamWriter.write`but it does return an `EventLoopFuture` which can be used to apply back pressure.

`AWSStreamWriters` can be chained together so the results of one can be processed by the next. This is used internally to implement the S3 signed streaming. The `AWSStreamWriter` results are sent to a `S3StreamWriter` which then sends its results onto the AsyncHTTPClient StreamWriter.

Now we have two full streaming solutions implemented. I hope to rewrite `StreamReader` using the new `AWSStreamWriter` instead of having it talk directly to AsyncHTTPClient. With this we can remove `S3ChunkedStreamReader` and use the chaining of StreamWriters for S3 signed `StreamReader` streams.