### PR TITLE
Add support for Endpoint discovery

### DIFF
--- a/Sources/SotoCore/AWSClient+EndpointDiscovery.swift
+++ b/Sources/SotoCore/AWSClient+EndpointDiscovery.swift
@@ -47,7 +47,7 @@ extension AWSClient {
                     on: eventLoop
                 )
             },
-            isDisabled: serviceConfig.options.contains(.disableEndpointDiscovery),
+            isEnabled: serviceConfig.options.contains(.enableEndpointDiscovery),
             endpointDiscovery: endpointDiscovery,
             eventLoop: eventLoop,
             logger: logger
@@ -92,7 +92,7 @@ extension AWSClient {
                     on: eventLoop
                 )
             },
-            isDisabled: serviceConfig.options.contains(.disableEndpointDiscovery),
+            isEnabled: serviceConfig.options.contains(.enableEndpointDiscovery),
             endpointDiscovery: endpointDiscovery,
             eventLoop: eventLoop,
             logger: logger
@@ -131,7 +131,7 @@ extension AWSClient {
                     on: eventLoop
                 )
             },
-            isDisabled: serviceConfig.options.contains(.disableEndpointDiscovery),
+            isEnabled: serviceConfig.options.contains(.enableEndpointDiscovery),
             endpointDiscovery: endpointDiscovery,
             eventLoop: eventLoop,
             logger: logger
@@ -176,7 +176,7 @@ extension AWSClient {
                     on: eventLoop
                 )
             },
-            isDisabled: serviceConfig.options.contains(.disableEndpointDiscovery),
+            isEnabled: serviceConfig.options.contains(.enableEndpointDiscovery),
             endpointDiscovery: endpointDiscovery,
             eventLoop: eventLoop,
             logger: logger
@@ -220,7 +220,7 @@ extension AWSClient {
                     stream: stream
                 )
             },
-            isDisabled: serviceConfig.options.contains(.disableEndpointDiscovery),
+            isEnabled: serviceConfig.options.contains(.enableEndpointDiscovery),
             endpointDiscovery: endpointDiscovery,
             eventLoop: eventLoop,
             logger: logger
@@ -229,12 +229,12 @@ extension AWSClient {
 
     private func execute<Output>(
         execute: @escaping (String?) -> EventLoopFuture<Output>,
-        isDisabled: Bool,
+        isEnabled: Bool,
         endpointDiscovery: EndpointDiscovery,
         eventLoop: EventLoop,
         logger: Logger
     ) -> EventLoopFuture<Output> {
-        guard !isDisabled else { return execute(nil) }
+        guard isEnabled || endpointDiscovery.isRequired else { return execute(nil) }
         // get endpoint
         if endpointDiscovery.isExpiring(within: 3 * 60) {
             let endPointFuture = endpointDiscovery.getEndpoint(logger: logger, on: eventLoop)

--- a/Sources/SotoCore/AWSClient+EndpointDiscovery.swift
+++ b/Sources/SotoCore/AWSClient+EndpointDiscovery.swift
@@ -1,0 +1,213 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2021 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIO
+
+extension AWSClient {
+    /// Execute an empty request and return a future with the output object generated from the response
+    /// - parameters:
+    ///     - operationName: Name of the AWS operation
+    ///     - path: path to append to endpoint URL
+    ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
+    ///     - serviceConfig: AWS service configuration used in request creation and signing
+    ///     - endpointDiscovery: Endpoint discovery helper
+    ///     - logger: Logger
+    ///     - eventLoop: Optional EventLoop to run everything on
+    /// - returns:
+    ///     Future containing output object that completes when response is received
+    public func execute(
+        operation operationName: String,
+        path: String,
+        httpMethod: HTTPMethod,
+        serviceConfig: AWSServiceConfig,
+        endpointDiscovery: EndpointDiscovery,
+        logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil
+    ) -> EventLoopFuture<Void> {
+        let eventLoop = eventLoop ?? eventLoopGroup.next()
+        // get endpoint
+        if endpointDiscovery.isExpiring(within: 5*60) {
+            return endpointDiscovery.getEndpoint(logger: logger, on: eventLoop).flatMap { endpoint in
+                return self.execute(
+                    operation: operationName,
+                    path: path,
+                    httpMethod: httpMethod,
+                    serviceConfig: serviceConfig.with(patch: .init(endpoint: endpoint)),
+                    logger: logger,
+                    on: eventLoop
+                )
+            }
+        } else {
+            return self.execute(
+                operation: operationName,
+                path: path,
+                httpMethod: httpMethod,
+                serviceConfig: serviceConfig.with(patch: .init(endpoint: endpointDiscovery.endpoint)),
+                logger: logger,
+                on: eventLoop
+            )
+        }
+    }
+
+    /// Execute a request with an input object and return a future with the output object generated from the response
+    /// - parameters:
+    ///     - operationName: Name of the AWS operation
+    ///     - path: path to append to endpoint URL
+    ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
+    ///     - serviceConfig: AWS service configuration used in request creation and signing
+    ///     - input: Input object
+    ///     - hostPrefix: Prefix to append to host name
+    ///     - endpointDiscovery: Endpoint discovery helper
+    ///     - logger: Logger
+    ///     - eventLoop: Optional EventLoop to run everything on
+    /// - returns:
+    ///     Future containing output object that completes when response is received
+    @discardableResult public func execute<Input: AWSEncodableShape>(
+        operation operationName: String,
+        path: String,
+        httpMethod: HTTPMethod,
+        serviceConfig: AWSServiceConfig,
+        input: Input,
+        hostPrefix: String? = nil,
+        endpointDiscovery: EndpointDiscovery,
+        logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil
+    ) -> EventLoopFuture<Void> {
+        let eventLoop = eventLoop ?? eventLoopGroup.next()
+        // get endpoint
+        if endpointDiscovery.isExpiring(within: 5*60) {
+            return endpointDiscovery.getEndpoint(logger: logger, on: eventLoop).flatMap { endpoint in
+                return self.execute(
+                    operation: operationName,
+                    path: path,
+                    httpMethod: httpMethod,
+                    serviceConfig: serviceConfig.with(patch: .init(endpoint: endpoint)),
+                    input: input,
+                    hostPrefix: hostPrefix,
+                    logger: logger,
+                    on: eventLoop
+                )
+            }
+        } else {
+            return self.execute(
+                operation: operationName,
+                path: path,
+                httpMethod: httpMethod,
+                serviceConfig: serviceConfig.with(patch: .init(endpoint: endpointDiscovery.endpoint)),
+                input: input,
+                hostPrefix: hostPrefix,
+                logger: logger,
+                on: eventLoop
+            )
+        }
+    }
+    
+    /// Execute an empty request and return a future with the output object generated from the response
+    /// - parameters:
+    ///     - operationName: Name of the AWS operation
+    ///     - path: path to append to endpoint URL
+    ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
+    ///     - serviceConfig: AWS service configuration used in request creation and signing
+    ///     - endpointDiscovery: Endpoint discovery helper
+    ///     - logger: Logger
+    ///     - eventLoop: Optional EventLoop to run everything on
+    /// - returns:
+    ///     Future containing output object that completes when response is received
+    public func execute<Output: AWSDecodableShape>(
+        operation operationName: String,
+        path: String,
+        httpMethod: HTTPMethod,
+        serviceConfig: AWSServiceConfig,
+        endpointDiscovery: EndpointDiscovery,
+        logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil
+    ) -> EventLoopFuture<Output> {
+        let eventLoop = eventLoop ?? eventLoopGroup.next()
+        // get endpoint
+        if endpointDiscovery.isExpiring(within: 5*60) {
+            return endpointDiscovery.getEndpoint(logger: logger, on: eventLoop).flatMap { endpoint in
+                return self.execute(
+                    operation: operationName,
+                    path: path,
+                    httpMethod: httpMethod,
+                    serviceConfig: serviceConfig.with(patch: .init(endpoint: endpoint)),
+                    logger: logger,
+                    on: eventLoop
+                )
+            }
+        } else {
+            return self.execute(
+                operation: operationName,
+                path: path,
+                httpMethod: httpMethod,
+                serviceConfig: serviceConfig.with(patch: .init(endpoint: endpointDiscovery.endpoint)),
+                logger: logger,
+                on: eventLoop
+            )
+        }
+    }
+
+    /// Execute a request with an input object and return a future with the output object generated from the response
+    /// - parameters:
+    ///     - operationName: Name of the AWS operation
+    ///     - path: path to append to endpoint URL
+    ///     - httpMethod: HTTP method to use ("GET", "PUT", "PUSH" etc)
+    ///     - serviceConfig: AWS service configuration used in request creation and signing
+    ///     - input: Input object
+    ///     - hostPrefix: Prefix to append to host name
+    ///     - endpointDiscovery: Endpoint discovery helper
+    ///     - logger: Logger
+    ///     - eventLoop: Optional EventLoop to run everything on
+    /// - returns:
+    ///     Future containing output object that completes when response is received
+    public func execute<Output: AWSDecodableShape, Input: AWSEncodableShape>(
+        operation operationName: String,
+        path: String,
+        httpMethod: HTTPMethod,
+        serviceConfig: AWSServiceConfig,
+        input: Input,
+        hostPrefix: String? = nil,
+        endpointDiscovery: EndpointDiscovery,
+        logger: Logger = AWSClient.loggingDisabled,
+        on eventLoop: EventLoop? = nil
+    ) -> EventLoopFuture<Output> {
+        let eventLoop = eventLoop ?? eventLoopGroup.next()
+        // get endpoint
+        if endpointDiscovery.isExpiring(within: 5*60) {
+            return endpointDiscovery.getEndpoint(logger: logger, on: eventLoop).flatMap { endpoint in
+                return self.execute(
+                    operation: operationName,
+                    path: path,
+                    httpMethod: httpMethod,
+                    serviceConfig: serviceConfig.with(patch: .init(endpoint: endpoint)),
+                    input: input,
+                    hostPrefix: hostPrefix,
+                    logger: logger,
+                    on: eventLoop
+                )
+            }
+        } else {
+            return self.execute(
+                operation: operationName,
+                path: path,
+                httpMethod: httpMethod,
+                serviceConfig: serviceConfig.with(patch: .init(endpoint: endpointDiscovery.endpoint)),
+                input: input,
+                hostPrefix: hostPrefix,
+                logger: logger,
+                on: eventLoop
+            )
+        }
+    }
+}

--- a/Sources/SotoCore/AWSServiceConfig.swift
+++ b/Sources/SotoCore/AWSServiceConfig.swift
@@ -44,7 +44,7 @@ public final class AWSServiceConfig {
     private let providedEndpoint: String?
     private let serviceEndpoints: [String: String]
     private let partitionEndpoints: [AWSPartition: (endpoint: String, region: Region)]
-    
+
     /// Create a ServiceConfig object
     ///
     /// - Parameters:
@@ -177,6 +177,7 @@ public final class AWSServiceConfig {
 
     /// Options used by client when processing requests
     public struct Options: OptionSet {
+        public typealias RawValue = Int
         public let rawValue: Int
 
         public init(rawValue: RawValue) {
@@ -193,6 +194,9 @@ public final class AWSServiceConfig {
 
         /// Use S3 transfer accelerated endpoint. You need to enable transfer acceleration on the bucket for this to work
         public static let s3UseTransferAcceleratedEndpoint = Options(rawValue: 1 << 2)
+
+        /// Disable endpoint discovery for services
+        public static let disableEndpointDiscovery = Options(rawValue: 1 << 3)
     }
 
     private init(

--- a/Sources/SotoCore/AWSServiceConfig.swift
+++ b/Sources/SotoCore/AWSServiceConfig.swift
@@ -44,7 +44,7 @@ public final class AWSServiceConfig {
     private let providedEndpoint: String?
     private let serviceEndpoints: [String: String]
     private let partitionEndpoints: [AWSPartition: (endpoint: String, region: Region)]
-
+    
     /// Create a ServiceConfig object
     ///
     /// - Parameters:
@@ -152,6 +152,7 @@ public final class AWSServiceConfig {
     /// Service config parameters you can patch
     public struct Patch {
         let region: Region?
+        let endpoint: String?
         let middlewares: [AWSServiceMiddleware]
         let timeout: TimeAmount?
         let byteBufferAllocator: ByteBufferAllocator?
@@ -159,12 +160,14 @@ public final class AWSServiceConfig {
 
         init(
             region: Region? = nil,
+            endpoint: String? = nil,
             middlewares: [AWSServiceMiddleware] = [],
             timeout: TimeAmount? = nil,
             byteBufferAllocator: ByteBufferAllocator? = nil,
             options: AWSServiceConfig.Options? = nil
         ) {
             self.region = region
+            self.endpoint = endpoint
             self.middlewares = middlewares
             self.timeout = timeout
             self.byteBufferAllocator = byteBufferAllocator
@@ -198,7 +201,7 @@ public final class AWSServiceConfig {
     ) {
         if let region = patch.region {
             self.region = region
-            self.endpoint = Self.getEndpoint(
+            self.endpoint = patch.endpoint ?? Self.getEndpoint(
                 endpoint: service.providedEndpoint,
                 region: region,
                 service: service.service,
@@ -207,7 +210,7 @@ public final class AWSServiceConfig {
             )
         } else {
             self.region = service.region
-            self.endpoint = service.endpoint
+            self.endpoint = patch.endpoint ?? service.endpoint
         }
         self.amzTarget = service.amzTarget
         self.service = service.service

--- a/Sources/SotoCore/AWSServiceConfig.swift
+++ b/Sources/SotoCore/AWSServiceConfig.swift
@@ -195,8 +195,8 @@ public final class AWSServiceConfig {
         /// Use S3 transfer accelerated endpoint. You need to enable transfer acceleration on the bucket for this to work
         public static let s3UseTransferAcceleratedEndpoint = Options(rawValue: 1 << 2)
 
-        /// Disable endpoint discovery for services
-        public static let disableEndpointDiscovery = Options(rawValue: 1 << 3)
+        /// Enable endpoint discovery for services where it isn't required
+        public static let enableEndpointDiscovery = Options(rawValue: 1 << 3)
     }
 
     private init(

--- a/Sources/SotoCore/EndpointDiscovery.swift
+++ b/Sources/SotoCore/EndpointDiscovery.swift
@@ -24,6 +24,7 @@ public struct AWSEndpoints {
             self.address = address
             self.cachePeriodInMinutes = cachePeriodInMinutes
         }
+
         /// An endpoint address.
         let address: String
         /// The TTL for the endpoint, in minutes.
@@ -33,7 +34,7 @@ public struct AWSEndpoints {
     public init(endpoints: [Endpoint]) {
         self.endpoints = endpoints
     }
-    
+
     let endpoints: [Endpoint]
 }
 
@@ -47,7 +48,7 @@ public class EndpointStorage {
     var promise: EventLoopPromise<String>?
     /// Lock access to class
     var lock = Lock()
-    
+
     /// Initialize endpoint storage
     /// - Parameter endpoint: Initial endpoint to use
     public init(endpoint: String) {
@@ -61,7 +62,7 @@ public class EndpointStorage {
             return self.expiration.timeIntervalSinceNow < interval
         }
     }
-    
+
     /// Get Endpoint from supplied closure, or wait on promise for Endpoint
     /// - Parameters:
     ///   - discover: Closure used to discover endpoint
@@ -102,13 +103,13 @@ public struct EndpointDiscovery {
     let discover: (Logger, EventLoop) -> EventLoopFuture<AWSEndpoints>
     let isRequired: Bool
     var endpoint: String? { storage.endpoint }
-    
+
     public init(storage: EndpointStorage, discover: @escaping (Logger, EventLoop) -> EventLoopFuture<AWSEndpoints>, required: Bool) {
         self.storage = storage
         self.discover = discover
         self.isRequired = required
     }
-    
+
     /// Will endpoint expire within a certain time
     public func isExpiring(within interval: TimeInterval) -> Bool {
         return self.storage.expiration.timeIntervalSinceNow < interval

--- a/Sources/SotoCore/EndpointDiscovery.swift
+++ b/Sources/SotoCore/EndpointDiscovery.swift
@@ -1,0 +1,116 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2021 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import struct Foundation.Date
+import struct Foundation.TimeInterval
+import NIO
+import NIOConcurrencyHelpers
+
+/// Endpoint list
+public struct AWSEndpoints {
+    public struct Endpoint {
+        public init(address: String, cachePeriodInMinutes: Int64) {
+            self.address = address
+            self.cachePeriodInMinutes = cachePeriodInMinutes
+        }
+        /// An endpoint address.
+        let address: String
+        /// The TTL for the endpoint, in minutes.
+        let cachePeriodInMinutes: Int64
+    }
+
+    public init(endpoints: [Endpoint]) {
+        self.endpoints = endpoints
+    }
+    
+    let endpoints: [Endpoint]
+}
+
+/// Class for storing Endpoint details
+public class EndpointStorage {
+    /// endpoint url
+    public var endpoint: String = ""
+    /// when endpoint expires
+    var expiration: Date
+    /// promise for endpoint discovery process
+    var promise: EventLoopPromise<String>?
+    /// Lock access to class
+    var lock = Lock()
+    
+    /// Initialize endpoint storage
+    public init() {
+        self.expiration = Date.distantPast
+    }
+
+    /// Will endpoint expire within a certain time
+    public func isExpiring(within interval: TimeInterval) -> Bool {
+        lock.withLock {
+            return self.expiration.timeIntervalSinceNow < interval
+        }
+    }
+    
+    /// Get Endpoint from supplied closure, or wait on promise for Endpoint
+    /// - Parameters:
+    ///   - discover: Closure used to discover endpoint
+    ///   - logger: Logger
+    ///   - eventLoop: EventLoop to run process on
+    /// - Returns: EventLoopFuture holding the endpoint
+    public func getEndpoint(
+        discover: @escaping (Logger, EventLoop) -> EventLoopFuture<AWSEndpoints>,
+        logger: Logger,
+        on eventLoop: EventLoop
+    ) -> EventLoopFuture<String> {
+        // lock access to class, until we exit the function
+        lock.lock()
+        defer { lock.unlock() }
+        // if promise is nil then run supplied closure, otherwise wait on result of promise
+        guard let promise = self.promise else {
+            let promise = eventLoop.makePromise(of: String.self)
+            let futureResult = discover(logger, eventLoop).map { response -> String in
+                let endpoint = response.endpoints[0]
+                self.lock.withLockVoid {
+                    self.endpoint = endpoint.address
+                    self.expiration = Date(timeIntervalSinceNow: TimeInterval(endpoint.cachePeriodInMinutes * 60))
+                    self.promise = nil
+                }
+                return response.endpoints[0].address
+            }
+            self.promise = promise
+            futureResult.cascade(to: promise)
+            return futureResult
+        }
+        return promise.futureResult
+    }
+}
+
+/// Helper object holding endpoint storage and closure used to discover endpoint
+public struct EndpointDiscovery {
+    let storage: EndpointStorage
+    let discover: (Logger, EventLoop) -> EventLoopFuture<AWSEndpoints>
+    var endpoint: String? { storage.endpoint }
+    
+    public init(storage: EndpointStorage, discover: @escaping (Logger, EventLoop) -> EventLoopFuture<AWSEndpoints>) {
+        self.storage = storage
+        self.discover = discover
+    }
+    
+    /// Will endpoint expire within a certain time
+    public func isExpiring(within interval: TimeInterval) -> Bool {
+        return self.storage.expiration.timeIntervalSinceNow < interval
+    }
+
+    public func getEndpoint(logger: Logger, on eventLoop: EventLoop) -> EventLoopFuture<String> {
+        return self.storage.getEndpoint(discover: self.discover, logger: logger, on: eventLoop)
+    }
+}

--- a/Sources/SotoCore/EndpointDiscovery.swift
+++ b/Sources/SotoCore/EndpointDiscovery.swift
@@ -81,7 +81,8 @@ public class EndpointStorage {
         guard let promise = self.promise else {
             let promise = eventLoop.makePromise(of: String.self)
             let futureResult = discover(logger, eventLoop).map { response -> String in
-                let endpoint = response.endpoints[0]
+                let index = Int.random(in: 0..<response.endpoints.count)
+                let endpoint = response.endpoints[index]
                 self.lock.withLockVoid {
                     self.endpoint = endpoint.address
                     self.expiration = Date(timeIntervalSinceNow: TimeInterval(endpoint.cachePeriodInMinutes * 60))

--- a/Sources/SotoCore/EndpointDiscovery.swift
+++ b/Sources/SotoCore/EndpointDiscovery.swift
@@ -98,11 +98,13 @@ public class EndpointStorage {
 public struct EndpointDiscovery {
     let storage: EndpointStorage
     let discover: (Logger, EventLoop) -> EventLoopFuture<AWSEndpoints>
+    let isRequired: Bool
     var endpoint: String? { storage.endpoint }
     
-    public init(storage: EndpointStorage, discover: @escaping (Logger, EventLoop) -> EventLoopFuture<AWSEndpoints>) {
+    public init(storage: EndpointStorage, discover: @escaping (Logger, EventLoop) -> EventLoopFuture<AWSEndpoints>, required: Bool) {
         self.storage = storage
         self.discover = discover
+        self.isRequired = required
     }
     
     /// Will endpoint expire within a certain time

--- a/Sources/SotoCore/EndpointDiscovery.swift
+++ b/Sources/SotoCore/EndpointDiscovery.swift
@@ -40,7 +40,7 @@ public struct AWSEndpoints {
 /// Class for storing Endpoint details
 public class EndpointStorage {
     /// endpoint url
-    public var endpoint: String = ""
+    public var endpoint: String
     /// when endpoint expires
     var expiration: Date
     /// promise for endpoint discovery process
@@ -49,8 +49,10 @@ public class EndpointStorage {
     var lock = Lock()
     
     /// Initialize endpoint storage
-    public init() {
+    /// - Parameter endpoint: Initial endpoint to use
+    public init(endpoint: String) {
         self.expiration = Date.distantPast
+        self.endpoint = endpoint
     }
 
     /// Will endpoint expire within a certain time

--- a/Sources/SotoCore/EndpointDiscovery.swift
+++ b/Sources/SotoCore/EndpointDiscovery.swift
@@ -57,7 +57,7 @@ public class EndpointStorage {
     }
 
     /// Will endpoint expire within a certain time
-    public func isExpiring(within interval: TimeInterval) -> Bool {
+    func isExpiring(within interval: TimeInterval) -> Bool {
         lock.withLock {
             return self.expiration.timeIntervalSinceNow < interval
         }
@@ -69,7 +69,7 @@ public class EndpointStorage {
     ///   - logger: Logger
     ///   - eventLoop: EventLoop to run process on
     /// - Returns: EventLoopFuture holding the endpoint
-    public func getEndpoint(
+    func getEndpoint(
         discover: @escaping (Logger, EventLoop) -> EventLoopFuture<AWSEndpoints>,
         logger: Logger,
         on eventLoop: EventLoop
@@ -112,11 +112,11 @@ public struct EndpointDiscovery {
     }
 
     /// Will endpoint expire within a certain time
-    public func isExpiring(within interval: TimeInterval) -> Bool {
+    func isExpiring(within interval: TimeInterval) -> Bool {
         return self.storage.expiration.timeIntervalSinceNow < interval
     }
 
-    public func getEndpoint(logger: Logger, on eventLoop: EventLoop) -> EventLoopFuture<String> {
+    func getEndpoint(logger: Logger, on eventLoop: EventLoop) -> EventLoopFuture<String> {
         return self.storage.getEndpoint(discover: self.discover, logger: logger, on: eventLoop)
     }
 }

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -82,7 +82,7 @@ public struct AWSSigner {
     ) -> HTTPHeaders {
         return signHeaders(url: url, method: method, headers: headers, body: body, omitSecurityToken: false, date: date)
     }
-    
+
     /// Generate signed headers, for a HTTP request
     public func signHeaders(
         url: URL,

--- a/Tests/SotoCoreTests/EndpointDiscoveryTests.swift
+++ b/Tests/SotoCoreTests/EndpointDiscoveryTests.swift
@@ -1,0 +1,176 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2020 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import SotoCore
+import SotoTestUtils
+import XCTest
+
+class EndpointDiscoveryTests: XCTestCase {
+    
+    class Service: AWSService {
+        
+        let client: AWSClient
+        let config: AWSServiceConfig
+        let endpointStorage: EndpointStorage
+        let endpointToDiscover: String
+        var getEndpointsCalledCount: Int
+        
+        required init(from: EndpointDiscoveryTests.Service, patch: AWSServiceConfig.Patch) {
+            self.client = from.client
+            self.config = from.config.with(patch: patch)
+            self.endpointStorage = from.endpointStorage
+            self.endpointToDiscover =  from.endpointToDiscover
+            self.getEndpointsCalledCount = from.getEndpointsCalledCount
+        }
+        
+        /// init
+        init(client: AWSClient, endpoint: String) {
+            self.client = client
+            self.config = .init(
+                region: .euwest1,
+                partition: .aws,
+                service: "Test",
+                serviceProtocol: .restjson,
+                apiVersion: "2021-08-08"
+            )
+            self.endpointStorage = EndpointStorage()
+            self.endpointToDiscover = endpoint
+            self.getEndpointsCalledCount = 0
+        }
+        
+        struct TestRequest: AWSEncodableShape {
+            static let _options: AWSShapeOptions = [.endpointDiscovery]
+        }
+        struct GetEndpointsRequest: AWSEncodableShape {}
+        
+        public func getEndpoints(logger: Logger, on eventLoop: EventLoop) -> EventLoopFuture<AWSEndpoints> {
+            self.getEndpointsCalledCount += 1
+            return eventLoop.scheduleTask(in: .milliseconds(200)) {
+                return AWSEndpoints(endpoints: [.init(address: self.endpointToDiscover, cachePeriodInMinutes: 60)])
+            }.futureResult
+        }
+        
+        @discardableResult public func test(_ input: TestRequest, logger: Logger = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
+            return self.client.execute(
+                operation: "Test",
+                path: "/test",
+                httpMethod: .GET,
+                serviceConfig: self.config,
+                input: input,
+                endpointDiscovery: .init(storage: self.endpointStorage, discover: getEndpoints),
+                logger: logger,
+                on: eventLoop
+            )
+        }
+        
+        public func getEndpointsDontCache(logger: Logger, on eventLoop: EventLoop) -> EventLoopFuture<AWSEndpoints> {
+            self.getEndpointsCalledCount += 1
+            return eventLoop.scheduleTask(in: .milliseconds(200)) {
+                return AWSEndpoints(endpoints: [.init(address: self.endpointToDiscover, cachePeriodInMinutes: 0)])
+            }.futureResult
+        }
+        
+        @discardableResult public func testDontCache(logger: Logger = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
+            return self.client.execute(
+                operation: "Test",
+                path: "/test",
+                httpMethod: .GET,
+                serviceConfig: self.config,
+                endpointDiscovery: .init(storage: self.endpointStorage, discover: getEndpointsDontCache),
+                logger: logger,
+                on: eventLoop
+            )
+        }
+    }
+    
+    func testCachingEndpointDiscovery() throws {
+        let awsServer = AWSTestServer(serviceProtocol: .json)
+        let client = AWSClient(httpClientProvider: .createNew)
+        defer {
+            XCTAssertNoThrow(try client.syncShutdown())
+            XCTAssertNoThrow(try awsServer.stop())
+        }
+        let service = Service(client: client, endpoint: awsServer.address)
+        let response = service.test(.init()).flatMap { _ in
+            service.test(.init())
+        }
+
+        var count = 0
+        try awsServer.processRaw { _ in
+            let response = AWSTestServer.Response(httpStatus: .ok, headers: [:], body: nil)
+            count += 1
+            if count > 1 {
+                return .result(response, continueProcessing: false)
+            } else {
+                return .result(response, continueProcessing: true)
+            }
+        }
+
+        try response.wait()
+        XCTAssertEqual(service.getEndpointsCalledCount, 1)
+    }
+    
+    func testConcurrentEndpointDiscovery() throws {
+        let awsServer = AWSTestServer(serviceProtocol: .json)
+        let client = AWSClient(httpClientProvider: .createNew)
+        defer {
+            XCTAssertNoThrow(try client.syncShutdown())
+            XCTAssertNoThrow(try awsServer.stop())
+        }
+        let service = Service(client: client, endpoint: awsServer.address)
+        let response1 = service.test(.init())
+        let response2 = service.test(.init())
+
+        var count = 0
+        try awsServer.processRaw { _ in
+            let response = AWSTestServer.Response(httpStatus: .ok, headers: [:], body: nil)
+            count += 1
+            if count > 1 {
+                return .result(response, continueProcessing: false)
+            } else {
+                return .result(response, continueProcessing: true)
+            }
+        }
+
+        _ = try response1.and(response2).wait()
+        XCTAssertEqual(service.getEndpointsCalledCount, 1)
+    }
+    
+    func testDontCacheEndpoint() throws {
+        let awsServer = AWSTestServer(serviceProtocol: .json)
+        let client = AWSClient(httpClientProvider: .createNew)
+        defer {
+            XCTAssertNoThrow(try client.syncShutdown())
+            XCTAssertNoThrow(try awsServer.stop())
+        }
+        let service = Service(client: client, endpoint: awsServer.address)
+        let response = service.testDontCache().flatMap { _ in
+            service.testDontCache()
+        }
+
+        var count = 0
+        try awsServer.processRaw { _ in
+            let response = AWSTestServer.Response(httpStatus: .ok, headers: [:], body: nil)
+            count += 1
+            if count > 1 {
+                return .result(response, continueProcessing: false)
+            } else {
+                return .result(response, continueProcessing: true)
+            }
+        }
+
+        try response.wait()
+        XCTAssertEqual(service.getEndpointsCalledCount, 2)
+    }
+}

--- a/Tests/SotoCoreTests/EndpointDiscoveryTests.swift
+++ b/Tests/SotoCoreTests/EndpointDiscoveryTests.swift
@@ -44,7 +44,7 @@ class EndpointDiscoveryTests: XCTestCase {
                 serviceProtocol: .restjson,
                 apiVersion: "2021-08-08"
             )
-            self.endpointStorage = EndpointStorage()
+            self.endpointStorage = EndpointStorage(endpoint: self.config.endpoint)
             self.endpointToDiscover = endpoint
             self.getEndpointsCalledCount = 0
         }

--- a/Tests/SotoCoreTests/EndpointDiscoveryTests.swift
+++ b/Tests/SotoCoreTests/EndpointDiscoveryTests.swift
@@ -89,6 +89,19 @@ class EndpointDiscoveryTests: XCTestCase {
                 on: eventLoop
             )
         }
+
+        @discardableResult public func testNotRequired(_ input: TestRequest, logger: Logger = AWSClient.loggingDisabled, on eventLoop: EventLoop? = nil) -> EventLoopFuture<Void> {
+            return self.client.execute(
+                operation: "Test",
+                path: "/test",
+                httpMethod: .GET,
+                serviceConfig: self.config,
+                input: input,
+                endpointDiscovery: .init(storage: self.endpointStorage, discover: self.getEndpoints, required: false),
+                logger: logger,
+                on: eventLoop
+            )
+        }
     }
 
     func testCachingEndpointDiscovery() throws {
@@ -182,8 +195,8 @@ class EndpointDiscoveryTests: XCTestCase {
             XCTAssertNoThrow(try awsServer.stop())
         }
         let service = Service(client: client, endpoint: awsServer.address)
-            .with(middlewares: TestEnvironment.middlewares, options: .disableEndpointDiscovery)
-        let response = service.test(.init(), logger: TestEnvironment.logger)
+            .with(middlewares: TestEnvironment.middlewares)
+        let response = service.testNotRequired(.init(), logger: TestEnvironment.logger)
 
         try awsServer.processRaw { request in
             TestEnvironment.logger.info("\(request)")

--- a/Tests/SotoCoreTests/EndpointDiscoveryTests.swift
+++ b/Tests/SotoCoreTests/EndpointDiscoveryTests.swift
@@ -49,10 +49,7 @@ class EndpointDiscoveryTests: XCTestCase {
             self.getEndpointsCalledCount = 0
         }
         
-        struct TestRequest: AWSEncodableShape {
-            static let _options: AWSShapeOptions = [.endpointDiscovery]
-        }
-        struct GetEndpointsRequest: AWSEncodableShape {}
+        struct TestRequest: AWSEncodableShape { }
         
         public func getEndpoints(logger: Logger, on eventLoop: EventLoop) -> EventLoopFuture<AWSEndpoints> {
             self.getEndpointsCalledCount += 1
@@ -68,7 +65,7 @@ class EndpointDiscoveryTests: XCTestCase {
                 httpMethod: .GET,
                 serviceConfig: self.config,
                 input: input,
-                endpointDiscovery: .init(storage: self.endpointStorage, discover: getEndpoints),
+                endpointDiscovery: .init(storage: self.endpointStorage, discover: getEndpoints, required: true),
                 logger: logger,
                 on: eventLoop
             )
@@ -87,7 +84,7 @@ class EndpointDiscoveryTests: XCTestCase {
                 path: "/test",
                 httpMethod: .GET,
                 serviceConfig: self.config,
-                endpointDiscovery: .init(storage: self.endpointStorage, discover: getEndpointsDontCache),
+                endpointDiscovery: .init(storage: self.endpointStorage, discover: getEndpointsDontCache, required: true),
                 logger: logger,
                 on: eventLoop
             )


### PR DESCRIPTION
DynamoDB and TimeStream both use endpoint discovery to provide endpoints to the user. For DynamoDB this is an optional feature but for TimeStream this is a requirement. This PR adds endpoint discovery internal to Soto instead of expecting the user to do this.

The code adds in five new versions of `AWSClient.execute` with additional parameter `endpointDiscovery`. This type contains storage for a cached endpoint and a closure to call to get a new endpoint. 

There are two types of endpoint acquisition: one where you are required to use the endpoint returned by endpoint discovery (TimeStream) and one where you can use the standard endpoint while endpoint discovery is in progress (DynamoDB). Both of these are supported. Given the DynamoDB calls are not dependent on the endpoint discovery to finish, the impact on DynamoDB calls is minimal. 

Because DynamoDB doesn't require endpoint discovery it is disabled by default. If you would like to enable it there is a new `AWSServiceConfig.Option` `enableEndpointDiscovery`.

Related Soto PR is https://github.com/soto-project/soto/pull/517