### PR TITLE
Add AWSPayload.asyncSequence

### DIFF
--- a/Sources/SotoCore/AWSShapes/Payload+async.swift
+++ b/Sources/SotoCore/AWSShapes/Payload+async.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2021 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=5.5)
+
+import NIOCore
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension AWSPayload {
+    /// Construct a stream payload from a `NIOFileHandle`
+    /// - Parameters:
+    ///   - fileHandle: NIO file handle
+    ///   - offset: optional offset into file. If not set it will use the current position in the file
+    ///   - size: size of block to load from file
+    ///   - fileIO: NonBlockingFileIO object
+    ///   - byteBufferAllocator: ByteBufferAllocator used during request upload
+    ///   - callback: Progress callback called during upload
+    public static func asyncSequence<AsyncSeq: AsyncSequence>(_ seq: AsyncSeq, size: Int?) -> Self where AsyncSeq.Element == ByteBuffer {
+        func stream(_ eventLoop: EventLoop) -> EventLoopFuture<StreamReaderResult> {
+            let promise = eventLoop.makePromise(of: StreamReaderResult.self)
+            promise.completeWithTask {
+                var iterator = seq.makeAsyncIterator()
+                if let buffer = try await iterator.next() {
+                    return .byteBuffer(buffer)
+                } else {
+                    return .end
+                }
+            }
+            return promise.futureResult
+        }
+        return AWSPayload(
+            payload: .stream(ChunkedStreamReader(size: size, read: stream))
+        )
+    }
+}
+
+#endif // compiler(>=5.5)

--- a/Sources/SotoCore/AWSShapes/Payload+async.swift
+++ b/Sources/SotoCore/AWSShapes/Payload+async.swift
@@ -18,7 +18,7 @@ import NIOCore
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 extension AWSPayload {
-    /// Construct a stream payload from a `NIOFileHandle`
+    /// Construct a stream payload from an `AsynSequence` of `ByteBuffers`
     /// - Parameters:
     ///   - seq: AsyncSequence providing ByteBuffers
     ///   - size: total size of sequence in bytes

--- a/Sources/SotoCore/AWSShapes/Payload+async.swift
+++ b/Sources/SotoCore/AWSShapes/Payload+async.swift
@@ -20,12 +20,8 @@ import NIOCore
 extension AWSPayload {
     /// Construct a stream payload from a `NIOFileHandle`
     /// - Parameters:
-    ///   - fileHandle: NIO file handle
-    ///   - offset: optional offset into file. If not set it will use the current position in the file
-    ///   - size: size of block to load from file
-    ///   - fileIO: NonBlockingFileIO object
-    ///   - byteBufferAllocator: ByteBufferAllocator used during request upload
-    ///   - callback: Progress callback called during upload
+    ///   - seq: AsyncSequence providing ByteBuffers
+    ///   - size: total size of sequence in bytes
     public static func asyncSequence<AsyncSeq: AsyncSequence>(_ seq: AsyncSeq, size: Int?) -> Self where AsyncSeq.Element == ByteBuffer {
         func stream(_ eventLoop: EventLoop) -> EventLoopFuture<StreamReaderResult> {
             let promise = eventLoop.makePromise(of: StreamReaderResult.self)

--- a/Sources/SotoCore/AWSShapes/Payload.swift
+++ b/Sources/SotoCore/AWSShapes/Payload.swift
@@ -41,7 +41,7 @@ public struct AWSPayload {
         byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator(),
         stream: @escaping (EventLoop) -> EventLoopFuture<StreamReaderResult>
     ) -> Self {
-        return AWSPayload(payload: .stream(ChunkedStreamReader(size: size, read: stream, byteBufferAllocator: byteBufferAllocator)))
+        return AWSPayload(payload: .stream(ChunkedStreamReader(size: size, read: stream)))
     }
 
     /// construct an empty payload
@@ -127,7 +127,7 @@ public struct AWSPayload {
             }
         }
 
-        return AWSPayload(payload: .stream(ChunkedStreamReader(size: size.map { Int($0) }, read: stream, byteBufferAllocator: byteBufferAllocator)))
+        return AWSPayload(payload: .stream(ChunkedStreamReader(size: size.map { Int($0) }, read: stream)))
     }
 
     /// construct a payload from a stream reader object.

--- a/Sources/SotoCore/HTTP/StreamReader.swift
+++ b/Sources/SotoCore/HTTP/StreamReader.swift
@@ -29,8 +29,6 @@ protocol StreamReader {
     var contentSize: Int? { get }
     /// function providing data to be streamed
     var read: (EventLoop) -> EventLoopFuture<StreamReaderResult> { get }
-    /// bytebuffer allocator
-    var byteBufferAllocator: ByteBufferAllocator { get }
 
     /// Update headers for this kind of streamed data
     /// - Parameter headers: headers to update
@@ -75,6 +73,4 @@ struct ChunkedStreamReader: StreamReader {
     let size: Int?
     /// function providing data to be streamed
     let read: (EventLoop) -> EventLoopFuture<StreamReaderResult>
-    /// bytebuffer allocator
-    var byteBufferAllocator: ByteBufferAllocator
 }

--- a/Sources/SotoCore/Message/AWSRequest.swift
+++ b/Sources/SotoCore/Message/AWSRequest.swift
@@ -64,7 +64,7 @@ public struct AWSRequest {
                     size: reader.size!,
                     seedSigningData: seedSigningData,
                     signer: signer,
-                    byteBufferAllocator: reader.byteBufferAllocator,
+                    byteBufferAllocator: byteBufferAllocator,
                     read: reader.read
                 )
                 let payload = AWSPayload.streamReader(s3Reader)

--- a/Tests/SotoCoreTests/AWSClientTests+async.swift
+++ b/Tests/SotoCoreTests/AWSClientTests+async.swift
@@ -109,6 +109,61 @@ class AWSClientAsyncTests: XCTestCase {
             XCTAssertEqual(output.i, 547)
         }
     }
+
+    func testRequestStreaming(config: AWSServiceConfig, client: AWSClient, server: AWSTestServer, bufferSize: Int, blockSize: Int) throws {
+        struct Input: AWSEncodableShape & AWSShapeWithPayload {
+            static var _payloadPath: String = "payload"
+            static var _payloadOptions: AWSShapePayloadOptions = [.allowStreaming, .raw]
+            let payload: AWSPayload
+            private enum CodingKeys: CodingKey {}
+        }
+        let data = createRandomBuffer(45, 9182, size: bufferSize)
+        var byteBuffer = ByteBufferAllocator().buffer(capacity: data.count)
+        byteBuffer.writeBytes(data)
+
+        let stream = AsyncStream<ByteBuffer>() { cont in
+            while byteBuffer.readableBytes > 0 {
+                let size = min(blockSize, byteBuffer.readableBytes)
+                let buffer = byteBuffer.readSlice(length: size)!
+                cont.yield(buffer)
+            }
+            cont.finish()
+        }
+        let input = Input(payload: .asyncSequence(stream, size: bufferSize))
+        let response = client.execute(
+            operation: "test",
+            path: "/",
+            httpMethod: .POST,
+            serviceConfig: config,
+            input: input,
+            logger: TestEnvironment.logger
+        )
+
+        try? server.processRaw { request in
+            let bytes = request.body.getBytes(at: 0, length: request.body.readableBytes)
+            XCTAssertEqual(bytes, data)
+            let response = AWSTestServer.Response(httpStatus: .ok, headers: [:], body: nil)
+            return .result(response)
+        }
+
+        try response.wait()
+    }
+
+    func testRequestStreaming() {
+        let awsServer = AWSTestServer(serviceProtocol: .json)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+        let config = createServiceConfig(endpoint: awsServer.address)
+        let client = createAWSClient(credentialProvider: .empty, httpClientProvider: .shared(httpClient))
+        defer {
+            XCTAssertNoThrow(try awsServer.stop())
+            XCTAssertNoThrow(try client.syncShutdown())
+            XCTAssertNoThrow(try httpClient.syncShutdown())
+        }
+
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: 16 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 128 * 1024, blockSize: 17 * 1024))
+        XCTAssertNoThrow(try self.testRequestStreaming(config: config, client: client, server: awsServer, bufferSize: 18 * 1024, blockSize: 47 * 1024))
+    }
 }
 
 #endif // compiler(>=5.5)


### PR DESCRIPTION
This adds AWSPayload.asyncSequence which allows you to provide an AsyncSequence of ByteBuffers to a request.

This will merge into the bigger async-await PR #431 