### PR TITLE
Fix compile issue with swift-nio in Xcode 13 GM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.3"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.7.2"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.0.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.3.0"),


### PR DESCRIPTION
Because of an issue with Xcode 13 GM SDK, swift-nio requires a workaround to compile (https://github.com/apple/swift-nio/issues/1955). This has been released in `2.32.3`.