### PR TITLE
Don't throw errors on failure to decode additional fields of AWS error

### DIFF
--- a/Sources/SotoCore/Message/AWSResponse.swift
+++ b/Sources/SotoCore/Message/AWSResponse.swift
@@ -271,7 +271,9 @@ public struct AWSResponse {
             var additionalFields: [String: String] = [:]
             for key in container.allKeys {
                 guard key.stringValue != "Code", key.stringValue != "Message" else { continue }
-                additionalFields[key.stringValue] = try container.decodeIfPresent(String.self, forKey: key)
+                do {
+                    additionalFields[key.stringValue] = try container.decodeIfPresent(String.self, forKey: key)
+                } catch {}
             }
             self.additionalFields = additionalFields
         }
@@ -292,7 +294,9 @@ public struct AWSResponse {
             var additionalFields: [String: String] = [:]
             for key in container.allKeys {
                 guard key.stringValue != "__type", key.stringValue != "message", key.stringValue != "Message" else { continue }
-                additionalFields[key.stringValue] = try container.decodeIfPresent(String.self, forKey: key)
+                do {
+                    additionalFields[key.stringValue] = try container.decodeIfPresent(String.self, forKey: key)
+                } catch {}
             }
             self.additionalFields = additionalFields
         }
@@ -313,7 +317,9 @@ public struct AWSResponse {
             var additionalFields: [String: String] = [:]
             for key in container.allKeys {
                 guard key.stringValue != "code", key.stringValue != "message", key.stringValue != "Message" else { continue }
-                additionalFields[key.stringValue] = try container.decodeIfPresent(String.self, forKey: key)
+                do {
+                    additionalFields[key.stringValue] = try container.decodeIfPresent(String.self, forKey: key)
+                } catch {}
             }
             self.additionalFields = additionalFields
         }

--- a/Tests/SotoCoreTests/AWSResponseTests.swift
+++ b/Tests/SotoCoreTests/AWSResponseTests.swift
@@ -262,7 +262,7 @@ class AWSResponseTests: XCTestCase {
         let response = AWSHTTPResponseImpl(
             status: .notFound,
             headers: HTTPHeaders(),
-            bodyData: #"{"__type":"ResourceNotFoundException", "Message": "Donald Where's Your Troosers?", "fault": "client"}"#.data(using: .utf8)!
+            bodyData: #"{"__type":"ResourceNotFoundException", "Message": "Donald Where's Your Troosers?", "fault": "client","CancellationReasons":1}"#.data(using: .utf8)!
         )
         let service = createServiceConfig(serviceProtocol: .json(version: "1.1"), errorType: ServiceErrorType.self)
 


### PR DESCRIPTION
When decoding an error returned by AWS, we attempt to extract any fields from the error that are non-standard and place them in a `Dictionary<String, String> called `additionalFields`. This ends up being not such a good idea because it assumes all additional fields will be strings. This change means if we decode an error which has a non string type additional field it will not throw an error and still create the error type expected.

This should fix https://github.com/soto-project/soto/issues/532