### PR TITLE
Hostname encoding (resurrected)

### DIFF
--- a/Sources/SotoCore/AWSServiceConfig.swift
+++ b/Sources/SotoCore/AWSServiceConfig.swift
@@ -60,7 +60,7 @@ public final class AWSServiceConfig {
     ///   - endpoint: Custom endpoint URL to use instead of standard AWS servers
     ///   - serviceEndpoints: Dictionary of endpoints to URLs
     ///   - partitionEndpoints: Default endpoint to use, if no region endpoint is supplied
-    ///   - errorType: Array of possible error types that the client can throw
+    ///   - errorType: Error type that the client can throw
     ///   - xmlNamespace: XML Namespace to be applied to request objects
     ///   - middlewares: Array of middlewares to apply to requests and responses
     ///   - timeout: Time out value for HTTP requests
@@ -203,7 +203,7 @@ public final class AWSServiceConfig {
         /// Enable endpoint discovery for services where it isn't required
         public static let enableEndpointDiscovery = Options(rawValue: 1 << 3)
 
-        /// Disable S3 siogned chunked uploads
+        /// Disable S3 signed chunked uploads
         public static let s3DisableChunkedUploads = Options(rawValue: 1 << 4)
     }
 

--- a/Sources/SotoCore/Doc/AWSMemberEncoding.swift
+++ b/Sources/SotoCore/Doc/AWSMemberEncoding.swift
@@ -16,13 +16,13 @@
 public struct AWSMemberEncoding {
     /// Location of AWSMemberEncoding.
     public enum Location {
-        case hostname(locationName: String)
-        case uri(locationName: String)
-        case querystring(locationName: String)
-        case header(locationName: String)
-        case headerPrefix(prefix: String)
+        case hostname(String)
+        case uri(String)
+        case querystring(String)
+        case header(String)
+        case headerPrefix(String)
         case statusCode
-        case body(locationName: String)
+        case body(String)
     }
 
     /// name of member

--- a/Sources/SotoCore/Doc/AWSMemberEncoding.swift
+++ b/Sources/SotoCore/Doc/AWSMemberEncoding.swift
@@ -16,6 +16,7 @@
 public struct AWSMemberEncoding {
     /// Location of AWSMemberEncoding.
     public enum Location {
+        case hostname(locationName: String)
         case uri(locationName: String)
         case querystring(locationName: String)
         case header(locationName: String)

--- a/Sources/SotoCore/Message/AWSRequest.swift
+++ b/Sources/SotoCore/Message/AWSRequest.swift
@@ -176,8 +176,11 @@ extension AWSRequest {
                     path = path
                         .replacingOccurrences(of: "{\(location)}", with: Self.urlEncodePathComponent(String(describing: value)))
                         .replacingOccurrences(of: "{\(location)+}", with: Self.urlEncodePath(String(describing: value)))
+
+                case .hostname(let location):
                     hostPrefix = hostPrefix?
                         .replacingOccurrences(of: "{\(location)}", with: Self.urlEncodePathComponent(String(describing: value)))
+
                 default:
                     memberVariablesCount += 1
                 }

--- a/Tests/SotoCoreTests/AWSClientTests.swift
+++ b/Tests/SotoCoreTests/AWSClientTests.swift
@@ -720,7 +720,7 @@ class AWSClientTests: XCTestCase {
     func testStreamingResponse() {
         struct Input: AWSEncodableShape {}
         struct Output: AWSDecodableShape & Encodable {
-            static let _encoding = [AWSMemberEncoding(label: "test", location: .header(locationName: "test"))]
+            static let _encoding = [AWSMemberEncoding(label: "test", location: .header("test"))]
             let test: String
         }
         let data = createRandomBuffer(45, 109, size: 128 * 1024)
@@ -772,7 +772,7 @@ class AWSClientTests: XCTestCase {
     func testStreamingDelegateFinished() {
         struct Input: AWSEncodableShape {}
         struct Output: AWSDecodableShape & Encodable {
-            static let _encoding = [AWSMemberEncoding(label: "test", location: .header(locationName: "test"))]
+            static let _encoding = [AWSMemberEncoding(label: "test", location: .header("test"))]
             let test: String
         }
         let bufferSize = 200 * 1024

--- a/Tests/SotoCoreTests/AWSRequestTests.swift
+++ b/Tests/SotoCoreTests/AWSRequestTests.swift
@@ -396,7 +396,7 @@ class AWSRequestTests: XCTestCase {
     func testHostPrefixLabel() {
         struct Input: AWSEncodableShape {
             static let _encoding: [AWSMemberEncoding] = [
-                .init(label: "accountId", location: .uri(locationName: "AccountId")),
+                .init(label: "accountId", location: .hostname(locationName: "AccountId")),
             ]
             let accountId: String
         }

--- a/Tests/SotoCoreTests/AWSRequestTests.swift
+++ b/Tests/SotoCoreTests/AWSRequestTests.swift
@@ -44,7 +44,7 @@ class AWSRequestTests: XCTestCase {
     func testCreateAwsRequestWithKeywordInHeader() {
         struct KeywordRequest: AWSEncodableShape {
             static var _encoding: [AWSMemberEncoding] = [
-                AWSMemberEncoding(label: "repeat", location: .header(locationName: "repeat")),
+                AWSMemberEncoding(label: "repeat", location: .header("repeat")),
             ]
             let `repeat`: String
         }
@@ -58,7 +58,7 @@ class AWSRequestTests: XCTestCase {
     func testCreateAwsRequestWithKeywordInQuery() {
         struct KeywordRequest: AWSEncodableShape {
             static var _encoding: [AWSMemberEncoding] = [
-                AWSMemberEncoding(label: "self", location: .querystring(locationName: "self")),
+                AWSMemberEncoding(label: "self", location: .querystring("self")),
             ]
             let `self`: String
         }
@@ -190,7 +190,7 @@ class AWSRequestTests: XCTestCase {
 
     func testHeaderEncoding() {
         struct Input: AWSEncodableShape {
-            static let _encoding = [AWSMemberEncoding(label: "h", location: .header(locationName: "header-member"))]
+            static let _encoding = [AWSMemberEncoding(label: "h", location: .header("header-member"))]
             let h: String
         }
         let input = Input(h: "TestHeader")
@@ -202,7 +202,7 @@ class AWSRequestTests: XCTestCase {
 
     func testQueryEncoding() {
         struct Input: AWSEncodableShape {
-            static let _encoding = [AWSMemberEncoding(label: "q", location: .querystring(locationName: "query"))]
+            static let _encoding = [AWSMemberEncoding(label: "q", location: .querystring("query"))]
             let q: String
         }
         let input = Input(q: "=3+5897^sdfjh&")
@@ -214,7 +214,7 @@ class AWSRequestTests: XCTestCase {
 
     func testQueryEncodedArray() {
         struct Input: AWSEncodableShape {
-            static let _encoding = [AWSMemberEncoding(label: "q", location: .querystring(locationName: "query"))]
+            static let _encoding = [AWSMemberEncoding(label: "q", location: .querystring("query"))]
             let q: [String]
         }
         let input = Input(q: ["=3+5897^sdfjh&", "test"])
@@ -227,7 +227,7 @@ class AWSRequestTests: XCTestCase {
 
     func testQueryEncodedDictionary() {
         struct Input: AWSEncodableShape {
-            static let _encoding = [AWSMemberEncoding(label: "q", location: .querystring(locationName: "query"))]
+            static let _encoding = [AWSMemberEncoding(label: "q", location: .querystring("query"))]
             let q: [String: Int]
         }
         let input = Input(q: ["one": 1, "two": 2])
@@ -239,7 +239,7 @@ class AWSRequestTests: XCTestCase {
 
     func testURIEncoding() {
         struct Input: AWSEncodableShape {
-            static let _encoding = [AWSMemberEncoding(label: "u", location: .uri(locationName: "key"))]
+            static let _encoding = [AWSMemberEncoding(label: "u", location: .uri("key"))]
             let u: String
         }
         let input = Input(u: "MyKey")
@@ -323,7 +323,7 @@ class AWSRequestTests: XCTestCase {
 
     func testPercentEncodePath() {
         struct Input: AWSEncodableShape {
-            static let _encoding: [AWSMemberEncoding] = [.init(label: "path", location: .uri(locationName: "path"))]
+            static let _encoding: [AWSMemberEncoding] = [.init(label: "path", location: .uri("path"))]
             let path: String
         }
         let input = Input(path: "Test me/once+")
@@ -337,7 +337,7 @@ class AWSRequestTests: XCTestCase {
 
     func testSortedArrayQuery() {
         struct Input: AWSEncodableShape {
-            static let _encoding: [AWSMemberEncoding] = [.init(label: "items", location: .querystring(locationName: "item"))]
+            static let _encoding: [AWSMemberEncoding] = [.init(label: "items", location: .querystring("item"))]
             let items: [String]
         }
         let input = Input(items: ["orange", "apple"])
@@ -350,8 +350,8 @@ class AWSRequestTests: XCTestCase {
     func testCustomEncoderInQuery() {
         struct Input: AWSEncodableShape {
             static let _encoding: [AWSMemberEncoding] = [
-                .init(label: "_date", location: .querystring(locationName: "date")),
-                .init(label: "_values", location: .querystring(locationName: "values")),
+                .init(label: "_date", location: .querystring("date")),
+                .init(label: "_values", location: .querystring("values")),
             ]
             @OptionalCustomCoding<HTTPHeaderDateCoder>
             var date: Date?
@@ -396,7 +396,7 @@ class AWSRequestTests: XCTestCase {
     func testHostPrefixLabel() {
         struct Input: AWSEncodableShape {
             static let _encoding: [AWSMemberEncoding] = [
-                .init(label: "accountId", location: .hostname(locationName: "AccountId")),
+                .init(label: "accountId", location: .hostname("AccountId")),
             ]
             let accountId: String
         }
@@ -475,7 +475,7 @@ class AWSRequestTests: XCTestCase {
         struct Input: AWSEncodableShape {
             static let _options: AWSShapeOptions = .md5ChecksumRequired
             static let _encoding: [AWSMemberEncoding] = [
-                .init(label: "checksum", location: .header(locationName: "Content-MD5")),
+                .init(label: "checksum", location: .header("Content-MD5")),
             ]
             let checksum: String?
             let q: [String: Int]
@@ -490,7 +490,7 @@ class AWSRequestTests: XCTestCase {
     func testHeaderPrefix() {
         struct Input: AWSEncodableShape {
             static let _encoding: [AWSMemberEncoding] = [
-                .init(label: "content", location: .headerPrefix(prefix: "x-aws-metadata-")),
+                .init(label: "content", location: .headerPrefix("x-aws-metadata-")),
             ]
             let content: [String: String]
         }

--- a/Tests/SotoCoreTests/AWSResponseTests.swift
+++ b/Tests/SotoCoreTests/AWSResponseTests.swift
@@ -22,7 +22,7 @@ import XCTest
 class AWSResponseTests: XCTestCase {
     func testHeaderResponseDecoding() {
         struct Output: AWSDecodableShape {
-            static let _encoding = [AWSMemberEncoding(label: "h", location: .header(locationName: "header-member"))]
+            static let _encoding = [AWSMemberEncoding(label: "h", location: .header("header-member"))]
             let h: String
             private enum CodingKeys: String, CodingKey {
                 case h = "header-member"
@@ -52,11 +52,11 @@ class AWSResponseTests: XCTestCase {
     func testHeaderResponseTypeDecoding() {
         struct Output: AWSDecodableShape {
             static let _encoding = [
-                AWSMemberEncoding(label: "string", location: .header(locationName: "string")),
-                AWSMemberEncoding(label: "string2", location: .header(locationName: "string2")),
-                AWSMemberEncoding(label: "double", location: .header(locationName: "double")),
-                AWSMemberEncoding(label: "integer", location: .header(locationName: "integer")),
-                AWSMemberEncoding(label: "bool", location: .header(locationName: "bool")),
+                AWSMemberEncoding(label: "string", location: .header("string")),
+                AWSMemberEncoding(label: "string2", location: .header("string2")),
+                AWSMemberEncoding(label: "double", location: .header("double")),
+                AWSMemberEncoding(label: "integer", location: .header("integer")),
+                AWSMemberEncoding(label: "bool", location: .header("bool")),
             ]
             let string: String
             let string2: String
@@ -135,7 +135,7 @@ class AWSResponseTests: XCTestCase {
 
     func testValidateXMLCodablePayloadResponse() {
         class Output: AWSDecodableShape & AWSShapeWithPayload {
-            static let _encoding = [AWSMemberEncoding(label: "contentType", location: .header(locationName: "content-type"))]
+            static let _encoding = [AWSMemberEncoding(label: "contentType", location: .header("content-type"))]
             static let _payloadPath: String = "name"
             let name: String
             let contentType: String
@@ -223,7 +223,7 @@ class AWSResponseTests: XCTestCase {
             static let _payloadPath: String = "body"
             static let _options: AWSShapeOptions = .rawPayload
             public static var _encoding = [
-                AWSMemberEncoding(label: "contentType", location: .header(locationName: "content-type")),
+                AWSMemberEncoding(label: "contentType", location: .header("content-type")),
             ]
             let body: AWSPayload
         }
@@ -377,7 +377,7 @@ class AWSResponseTests: XCTestCase {
     func testHeaderPrefixFromDictionary() {
         struct Output: AWSDecodableShape {
             static let _encoding: [AWSMemberEncoding] = [
-                .init(label: "content", location: .headerPrefix(prefix: "prefix-")),
+                .init(label: "content", location: .headerPrefix("prefix-")),
             ]
             let content: [String: String]
             private enum CodingKeys: String, CodingKey {
@@ -399,7 +399,7 @@ class AWSResponseTests: XCTestCase {
     func testHeaderPrefixFromXML() {
         struct Output: AWSDecodableShape {
             static let _encoding: [AWSMemberEncoding] = [
-                .init(label: "content", location: .headerPrefix(prefix: "prefix-")),
+                .init(label: "content", location: .headerPrefix("prefix-")),
             ]
             let content: [String: String]
             let body: String

--- a/Tests/SotoCoreTests/TimeStampTests.swift
+++ b/Tests/SotoCoreTests/TimeStampTests.swift
@@ -100,7 +100,7 @@ class TimeStampTests: XCTestCase {
     func testDecodeHeader() {
         do {
             struct A: AWSDecodableShape {
-                static let _encoding = [AWSMemberEncoding(label: "date", location: .header(locationName: "Date"))]
+                static let _encoding = [AWSMemberEncoding(label: "date", location: .header("Date"))]
                 let date: Date
                 private enum CodingKeys: String, CodingKey {
                     case date = "Date"


### PR DESCRIPTION
Managed to lose this in a rebase from main to 6.x.x