### PR TITLE
Make AWSHTTPClient internal to project

### DIFF
--- a/Benchmark/Sources/soto-benchmark/AWSClientSuite.swift
+++ b/Benchmark/Sources/soto-benchmark/AWSClientSuite.swift
@@ -29,8 +29,8 @@ struct RequestThrowMiddleware: AWSServiceMiddleware {
 
 struct HeaderShape: AWSEncodableShape {
     static let _encoding: [AWSMemberEncoding] = [
-        .init(label: "a", location: .header(locationName: "A")),
-        .init(label: "b", location: .header(locationName: "B")),
+        .init(label: "a", location: .header("A")),
+        .init(label: "b", location: .header("B")),
     ]
     let a: String
     let b: Int
@@ -38,8 +38,8 @@ struct HeaderShape: AWSEncodableShape {
 
 struct QueryShape: AWSEncodableShape {
     static let _encoding: [AWSMemberEncoding] = [
-        .init(label: "a", location: .querystring(locationName: "A")),
-        .init(label: "b", location: .querystring(locationName: "B")),
+        .init(label: "a", location: .querystring("A")),
+        .init(label: "b", location: .querystring("B")),
     ]
     let a: String
     let b: Int

--- a/Sources/SotoCore/AWSClient+EndpointDiscovery.swift
+++ b/Sources/SotoCore/AWSClient+EndpointDiscovery.swift
@@ -203,7 +203,7 @@ extension AWSClient {
         endpointDiscovery: AWSEndpointDiscovery,
         logger: Logger = AWSClient.loggingDisabled,
         on eventLoop: EventLoop? = nil,
-        stream: @escaping AWSHTTPClient.ResponseStream
+        stream: @escaping AWSResponseStream
     ) -> EventLoopFuture<Output> {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         return self.execute(

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -41,7 +41,7 @@ public final class AWSClient {
     /// Middleware code to be applied to requests and responses
     public let middlewares: [AWSServiceMiddleware]
     /// HTTP client used by AWSClient
-    public let httpClient: AWSHTTPClient
+    public let httpClient: HTTPClient
     /// Keeps a record of how we obtained the HTTP client
     let httpClientProvider: HTTPClientProvider
     /// EventLoopGroup used by AWSClient
@@ -218,7 +218,7 @@ public final class AWSClient {
     public enum HTTPClientProvider {
         /// HTTP Client will be provided by the user. Owner of this group is responsible for its lifecycle. Any HTTPClient that conforms to
         /// `AWSHTTPClient` can be specified here including AsyncHTTPClient
-        case shared(AWSHTTPClient)
+        case shared(HTTPClient)
         /// HTTP Client will be created by the client using provided EventLoopGroup. When `shutdown` is called, created `HTTPClient`
         /// will be shut down as well.
         case createNewWithEventLoopGroup(EventLoopGroup)
@@ -434,7 +434,7 @@ extension AWSClient {
         hostPrefix: String? = nil,
         logger: Logger = AWSClient.loggingDisabled,
         on eventLoop: EventLoop? = nil,
-        stream: @escaping AWSHTTPClient.ResponseStream
+        stream: @escaping AWSResponseStream
     ) -> EventLoopFuture<Output> {
         return execute(
             operation: operationName,

--- a/Sources/SotoCore/AsyncAwaitSupport/AWSClient+EndpointDiscovery+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/AWSClient+EndpointDiscovery+async.swift
@@ -207,7 +207,7 @@ extension AWSClient {
         endpointDiscovery: AWSEndpointDiscovery,
         logger: Logger = AWSClient.loggingDisabled,
         on eventLoop: EventLoop? = nil,
-        stream: @escaping AWSHTTPClient.ResponseStream
+        stream: @escaping AWSResponseStream
     ) async throws -> Output {
         let eventLoop = eventLoop ?? eventLoopGroup.next()
         return try await self.execute(

--- a/Sources/SotoCore/AsyncAwaitSupport/AWSClient+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/AWSClient+async.swift
@@ -208,7 +208,7 @@ extension AWSClient {
         hostPrefix: String? = nil,
         logger: Logger = AWSClient.loggingDisabled,
         on eventLoop: EventLoop? = nil,
-        stream: @escaping AWSHTTPClient.ResponseStream
+        stream: @escaping AWSResponseStream
     ) async throws -> Output {
         return try await self.execute(
             operation: operationName,

--- a/Sources/SotoCore/Credential/CredentialProvider.swift
+++ b/Sources/SotoCore/Credential/CredentialProvider.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import AsyncHTTPClient
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
@@ -43,7 +44,7 @@ public struct CredentialProviderFactory {
     /// The initialization context for a `ContextProvider`
     public struct Context {
         /// The `AWSClient`s internal `HTTPClient`
-        public let httpClient: AWSHTTPClient
+        public let httpClient: HTTPClient
         /// The `EventLoop` that the `CredentialProvider` should use for credential refreshs
         public let eventLoop: EventLoop
         /// The `Logger` attached to the AWSClient

--- a/Sources/SotoCore/Credential/STSAssumeRole.swift
+++ b/Sources/SotoCore/Credential/STSAssumeRole.swift
@@ -11,6 +11,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
+import AsyncHTTPClient
 import Foundation
 
 struct STSAssumeRoleRequest: AWSEncodableShape {
@@ -108,7 +110,7 @@ struct STSAssumeRoleCredentialProvider: CredentialProviderWithClient {
         request: STSAssumeRoleRequest,
         credentialProvider: CredentialProviderFactory,
         region: Region,
-        httpClient: AWSHTTPClient,
+        httpClient: HTTPClient,
         endpoint: String? = nil
     ) {
         self.client = AWSClient(credentialProvider: credentialProvider, httpClientProvider: .shared(httpClient))

--- a/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
+++ b/Sources/SotoCore/HTTP/AsyncHTTPClient.swift
@@ -25,7 +25,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
     ///   - timeout: If execution is idle for longer than timeout then throw error
     ///   - eventLoop: eventLoop to run request on
     /// - Returns: EventLoopFuture that will be fulfilled with request response
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<AWSHTTPResponse> {
+    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<AWSHTTPResponse> {
         let requestBody: AsyncHTTPClient.HTTPClient.Body?
         var requestHeaders = request.headers
 
@@ -58,7 +58,7 @@ extension AsyncHTTPClient.HTTPClient: AWSHTTPClient {
         }
     }
 
-    public func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger, stream: @escaping ResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
+    func execute(request: AWSHTTPRequest, timeout: TimeAmount, on eventLoop: EventLoop, logger: Logger, stream: @escaping AWSResponseStream) -> EventLoopFuture<AWSHTTPResponse> {
         let requestBody: AsyncHTTPClient.HTTPClient.Body?
         if case .byteBuffer(let body) = request.body.payload {
             requestBody = .byteBuffer(body)


### PR DESCRIPTION
So we can change it without requiring a major release
This will mean AsyncHTTPClient is the only HTTP client you can use with Soto