### PR TITLE
Remove retry on NIOConnectionError as AsyncHTTPClient does this for us

### DIFF
--- a/Sources/SotoCore/RetryPolicy.swift
+++ b/Sources/SotoCore/RetryPolicy.swift
@@ -93,10 +93,10 @@ extension StandardRetryPolicy {
                 }
             }
             return .dontRetry
-#if DEBUG
+        #if DEBUG
         case let httpClientError as HTTPClientError where httpClientError == .remoteConnectionClosed:
             return .retry(wait: calculateRetryWaitTime(attempt: attempt))
-#endif
+        #endif
         default:
             return .dontRetry
         }

--- a/Sources/SotoCore/RetryPolicy.swift
+++ b/Sources/SotoCore/RetryPolicy.swift
@@ -93,8 +93,10 @@ extension StandardRetryPolicy {
                 }
             }
             return .dontRetry
+#if DEBUG
         case let httpClientError as HTTPClientError where httpClientError == .remoteConnectionClosed:
             return .retry(wait: calculateRetryWaitTime(attempt: attempt))
+#endif
         default:
             return .dontRetry
         }

--- a/Sources/SotoCore/RetryPolicy.swift
+++ b/Sources/SotoCore/RetryPolicy.swift
@@ -95,8 +95,6 @@ extension StandardRetryPolicy {
             return .dontRetry
         case let httpClientError as HTTPClientError where httpClientError == .remoteConnectionClosed:
             return .retry(wait: calculateRetryWaitTime(attempt: attempt))
-        case is NIOConnectionError:
-            return .retry(wait: calculateRetryWaitTime(attempt: attempt))
         default:
             return .dontRetry
         }


### PR DESCRIPTION
Changed testCustomRetryPolicy test as it depended on retrying on NIOConnectionError