### PR TITLE
Swift Concurrency Availability macOS 10.15, iOS 13, tvOS 13 ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .build
 .swiftpm
+.vscode
 /Packages
 /*.xcodeproj
 Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -25,10 +25,10 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.34.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.36.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.7.2"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.0.0"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.6.4"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.8.1"),
         .package(url: "https://github.com/adam-fowler/jmespath.swift.git", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/SotoCore/AWSShapes/Payload+async.swift
+++ b/Sources/SotoCore/AWSShapes/Payload+async.swift
@@ -16,7 +16,7 @@
 
 import NIOCore
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension AWSPayload {
     /// Construct a stream payload from an `AsynSequence` of `ByteBuffers`
     /// - Parameters:

--- a/Sources/SotoCore/AsyncAwaitSupport/AWSClient+EndpointDiscovery+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/AWSClient+EndpointDiscovery+async.swift
@@ -17,7 +17,7 @@
 import Logging
 import NIOCore
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension AWSClient {
     /// Execute an empty request and return a future with the output object generated from the response
     /// - parameters:

--- a/Sources/SotoCore/AsyncAwaitSupport/AWSClient+Paginate+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/AWSClient+Paginate+async.swift
@@ -17,7 +17,7 @@
 import Logging
 import NIOCore
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension AWSClient {
     /// Used to access paginated results.
     public struct PaginatorSequence<Input: AWSPaginateToken, Output: AWSShape>: AsyncSequence where Input.Token: Equatable {

--- a/Sources/SotoCore/AsyncAwaitSupport/AWSClient+Waiter+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/AWSClient+Waiter+async.swift
@@ -17,7 +17,7 @@
 import Logging
 import NIOCore
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension AWSClient {
     /// Returns when waiter polling returns a success state
     /// or returns an error if the polling returns an error or timesout

--- a/Sources/SotoCore/AsyncAwaitSupport/AWSClient+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/AWSClient+async.swift
@@ -21,7 +21,7 @@ import Metrics
 import NIOCore
 import SotoSignerV4
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension AWSClient {
     /// execute a request with an input object and return a future with an empty response
     /// - parameters:

--- a/Sources/SotoCore/AsyncAwaitSupport/AWSService+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/AWSService+async.swift
@@ -18,7 +18,7 @@ import struct Foundation.URL
 import NIOCore
 
 /// Protocol for services objects. Contains a client to communicate with AWS and config for defining how to communicate
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension AWSService {
     /// Generate a signed URL
     /// - parameters:

--- a/Sources/SotoCore/AsyncAwaitSupport/CredentialProvider+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/CredentialProvider+async.swift
@@ -19,7 +19,7 @@ import NIOCore
 import SotoSignerV4
 
 /// Async Protocol for providing credentials
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public protocol AsyncCredentialProvider: CredentialProvider {
     /// Return credential
     /// - Parameters:
@@ -28,7 +28,7 @@ public protocol AsyncCredentialProvider: CredentialProvider {
     func getCredential(on eventLoop: EventLoop, logger: Logger) async throws -> Credential
 }
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 extension AsyncCredentialProvider {
     public func getCredential(on eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<Credential> {
         let promise = eventLoop.makePromise(of: Credential.self)

--- a/Sources/SotoTestUtils/TestUtils+async.swift
+++ b/Sources/SotoTestUtils/TestUtils+async.swift
@@ -19,7 +19,7 @@ import Logging
 import SotoCore
 import XCTest
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public func XCTRunAsyncAndBlock(_ closure: @escaping () async throws -> Void) {
     let dg = DispatchGroup()
     dg.enter()

--- a/Tests/SotoCoreTests/AWSClientTests+async.swift
+++ b/Tests/SotoCoreTests/AWSClientTests+async.swift
@@ -27,7 +27,7 @@ import SotoTestUtils
 import SotoXML
 import XCTest
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 class AWSClientAsyncTests: XCTestCase {
     func testGetCredential() {
         struct MyCredentialProvider: AsyncCredentialProvider {

--- a/Tests/SotoCoreTests/AWSServiceTests+async.swift
+++ b/Tests/SotoCoreTests/AWSServiceTests+async.swift
@@ -18,7 +18,7 @@
 import SotoTestUtils
 import XCTest
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class AWSServiceAsyncTests: XCTestCase {
     struct TestService: AWSService {
         var client: AWSClient

--- a/Tests/SotoCoreTests/Credential/CredentialProviderTests+async.swift
+++ b/Tests/SotoCoreTests/Credential/CredentialProviderTests+async.swift
@@ -19,7 +19,7 @@ import SotoCore
 import SotoTestUtils
 import XCTest
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 class AsyncCredentialProviderTests: XCTestCase {
     func testAsyncCredentialProvider() {
         struct TestAsyncProvider: AsyncCredentialProvider {

--- a/Tests/SotoCoreTests/EndpointDiscoveryTests+async.swift
+++ b/Tests/SotoCoreTests/EndpointDiscoveryTests+async.swift
@@ -19,7 +19,7 @@ import SotoCore
 import SotoTestUtils
 import XCTest
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 class EndpointDiscoveryAsyncTests: XCTestCase {
     class Service: AWSService {
         let client: AWSClient

--- a/Tests/SotoCoreTests/PaginateTests+async.swift
+++ b/Tests/SotoCoreTests/PaginateTests+async.swift
@@ -21,7 +21,7 @@ import NIOPosix
 import SotoTestUtils
 import XCTest
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class PaginateAsyncTests: XCTestCase {
     enum Error: Swift.Error {
         case didntFindToken

--- a/Tests/SotoCoreTests/WaiterTests+async.swift
+++ b/Tests/SotoCoreTests/WaiterTests+async.swift
@@ -18,7 +18,7 @@
 import SotoTestUtils
 import XCTest
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class WaiterAsyncTests: XCTestCase {
     var awsServer: AWSTestServer!
     var config: AWSServiceConfig!


### PR DESCRIPTION
… and watchOS 6

This updates the main branch and what will be version 6.x.x