### PR TITLE
Revert availability check changes for earlier platform versions

### DIFF
--- a/Sources/SotoCore/AWSShapes/Payload+async.swift
+++ b/Sources/SotoCore/AWSShapes/Payload+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import NIOCore
 
@@ -41,4 +41,4 @@ extension AWSPayload {
     }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/SotoCore/AsyncAwaitSupport/AWSClient+EndpointDiscovery+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/AWSClient+EndpointDiscovery+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import Logging
 import NIOCore
@@ -264,4 +264,4 @@ extension AWSClient {
     }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/SotoCore/AsyncAwaitSupport/AWSClient+Paginate+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/AWSClient+Paginate+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import Logging
 import NIOCore
@@ -89,4 +89,4 @@ extension AWSClient {
     }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/SotoCore/AsyncAwaitSupport/AWSClient+Waiter+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/AWSClient+Waiter+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import Logging
 import NIOCore
@@ -40,4 +40,4 @@ extension AWSClient {
     }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/SotoCore/AsyncAwaitSupport/AWSClient+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/AWSClient+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import Dispatch
 import Foundation
@@ -370,4 +370,4 @@ extension AWSClient {
     }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/SotoCore/AsyncAwaitSupport/AWSService+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/AWSService+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import struct Foundation.URL
 import NIOCore
@@ -59,4 +59,4 @@ extension AWSService {
     }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/SotoCore/AsyncAwaitSupport/CredentialProvider+async.swift
+++ b/Sources/SotoCore/AsyncAwaitSupport/CredentialProvider+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import Logging
 import NIOCore
@@ -37,4 +37,4 @@ extension AsyncCredentialProvider {
     }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Sources/SotoTestUtils/TestUtils+async.swift
+++ b/Sources/SotoTestUtils/TestUtils+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import Foundation
 import Logging
@@ -34,4 +34,4 @@ public func XCTRunAsyncAndBlock(_ closure: @escaping () async throws -> Void) {
     dg.wait()
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Tests/SotoCoreTests/AWSClientTests+async.swift
+++ b/Tests/SotoCoreTests/AWSClientTests+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import AsyncHTTPClient
 import Dispatch
@@ -184,4 +184,4 @@ class AWSClientAsyncTests: XCTestCase {
     }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Tests/SotoCoreTests/AWSServiceTests+async.swift
+++ b/Tests/SotoCoreTests/AWSServiceTests+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 @testable import SotoCore
 import SotoTestUtils
@@ -77,4 +77,4 @@ final class AWSServiceAsyncTests: XCTestCase {
     }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Tests/SotoCoreTests/Credential/CredentialProviderTests+async.swift
+++ b/Tests/SotoCoreTests/Credential/CredentialProviderTests+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import NIOCore
 import SotoCore
@@ -43,4 +43,4 @@ class AsyncCredentialProviderTests: XCTestCase {
     }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Tests/SotoCoreTests/EndpointDiscoveryTests+async.swift
+++ b/Tests/SotoCoreTests/EndpointDiscoveryTests+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import NIOCore
 import SotoCore
@@ -218,4 +218,4 @@ class EndpointDiscoveryAsyncTests: XCTestCase {
     }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Tests/SotoCoreTests/PaginateTests+async.swift
+++ b/Tests/SotoCoreTests/PaginateTests+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 import AsyncHTTPClient
 import NIOCore
@@ -237,4 +237,4 @@ final class PaginateAsyncTests: XCTestCase {
     }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Tests/SotoCoreTests/WaiterTests+async.swift
+++ b/Tests/SotoCoreTests/WaiterTests+async.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 @testable import SotoCore
 import SotoTestUtils
@@ -79,4 +79,4 @@ final class WaiterAsyncTests: XCTestCase {
     }
 }
 
-#endif // compiler(>=5.5) && canImport(_Concurrency)
+#endif // compiler(>=5.5.2) && canImport(_Concurrency)


### PR DESCRIPTION
Given the availability checks are causing issue in older Xcodes I'm thinking of reverting these changes