### PR TITLE
Fix empty query protocol requests

### DIFF
--- a/Sources/SotoCore/Message/AWSRequest.swift
+++ b/Sources/SotoCore/Message/AWSRequest.swift
@@ -112,7 +112,14 @@ extension AWSRequest {
         self.operation = operationName
         self.httpMethod = httpMethod
         self.httpHeaders = headers
-        self.body = .empty
+        // Query and EC2 protocols require the Action and API Version in the body
+        switch configuration.serviceProtocol {
+        case .query, .ec2:
+            let params = ["Action": operationName, "Version": configuration.apiVersion]
+            self.body = try .text(QueryEncoder().encode(params)!)
+        default:  
+            self.body = .empty
+        }
 
         addStandardHeaders()
     }

--- a/Sources/SotoCore/Message/AWSRequest.swift
+++ b/Sources/SotoCore/Message/AWSRequest.swift
@@ -117,7 +117,7 @@ extension AWSRequest {
         case .query, .ec2:
             let params = ["Action": operationName, "Version": configuration.apiVersion]
             self.body = try .text(QueryEncoder().encode(params)!)
-        default:  
+        default:
             self.body = .empty
         }
 

--- a/Tests/SotoCoreTests/AWSRequestTests.swift
+++ b/Tests/SotoCoreTests/AWSRequestTests.swift
@@ -237,6 +237,13 @@ class AWSRequestTests: XCTestCase {
         XCTAssertEqual(request?.url.absoluteString, "https://myservice.us-east-2.amazonaws.com/?one=1&two=2")
     }
 
+    func testQueryProtocolEmptyRequest() {
+        let config = createServiceConfig(region: .useast2, service: "myservice", serviceProtocol: .query)
+        var request: AWSRequest?
+        XCTAssertNoThrow(request = try AWSRequest(operation: "Test", path: "/", httpMethod: .GET, configuration: config))
+        XCTAssertEqual(request?.body.asString(), "Action=Test&Version=01-01-2001")
+    }
+
     func testURIEncoding() {
         struct Input: AWSEncodableShape {
             static let _encoding = [AWSMemberEncoding(label: "u", location: .uri("key"))]


### PR DESCRIPTION
Body should still contain Version and Action keys. It appears some services don't care but SES does see https://github.com/soto-project/soto/issues/580