### PR TITLE
Remove sequential spaces in header values in canonical request

### DIFF
--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -300,7 +300,7 @@ public struct AWSSigner {
         let canonicalHeaders = signingData.headersToSign
             .map { (key: $0.key.lowercased(), value: $0.value) }
             .sorted { $0.key < $1.key }
-            .map { return "\($0.key):\($0.value.trimmingCharacters(in: CharacterSet.whitespaces))" }
+            .map { return "\($0.key):\($0.value.trimmingCharacters(in: CharacterSet.whitespaces).removeSequentialWhitespace())" }
             .joined(separator: "\n")
         let canonicalPath: String
         let urlComps = URLComponents(url: signingData.unsignedURL, resolvingAgainstBaseURL: false)!
@@ -447,5 +447,15 @@ public extension URL {
             path += "/"
         }
         return path
+    }
+}
+
+fileprivate extension String {
+    func removeSequentialWhitespace() -> String {
+        return reduce(into: "") { result, character in
+            if result.last?.isWhitespace != true || character.isWhitespace == false {
+                result.append(character)
+            }
+        }
     }
 }


### PR DESCRIPTION
This is from the AWS docs on signing requests
```
To create the canonical headers list, convert all header names to lowercase and remove leading spaces and trailing spaces. Convert sequential spaces in the header value to a single space.
```
This should resolve https://github.com/soto-project/soto/issues/584