### PR TITLE
Remove certain headers from signature

### DIFF
--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -269,16 +269,21 @@ public struct AWSSigner: _SignerSendable {
             }
 
             let headersNotToSign: Set<String> = [
-                "Authorization",
+                "authorization",
+                "content-length",
+                "content-type",
+                "expect",
+                "user-agent",
             ]
             var headersToSign: [String: String] = [:]
             var signedHeadersArray: [String] = []
             for header in headers {
-                if headersNotToSign.contains(header.name) {
+                let lowercasedHeaderName = header.name.lowercased()
+                if headersNotToSign.contains(lowercasedHeaderName) {
                     continue
                 }
-                headersToSign[header.name] = header.value
-                signedHeadersArray.append(header.name.lowercased())
+                headersToSign[lowercasedHeaderName] = header.value
+                signedHeadersArray.append(lowercasedHeaderName)
             }
             self.headersToSign = headersToSign
             self.signedHeaders = signedHeadersArray.sorted().joined(separator: ";")

--- a/Tests/SotoSignerV4Tests/AWSSignerTests.swift
+++ b/Tests/SotoSignerV4Tests/AWSSignerTests.swift
@@ -51,7 +51,7 @@ final class AWSSignerTests: XCTestCase {
     func testSignPutHeaders() {
         let signer = AWSSigner(credentials: credentials, name: "sns", region: "eu-west-1")
         let headers = signer.signHeaders(url: URL(string: "https://sns.eu-west-1.amazonaws.com/")!, method: .POST, headers: ["Content-Type": "application/x-www-form-urlencoded; charset=utf-8"], body: .string("Action=ListTopics&Version=2010-03-31"), date: Date(timeIntervalSinceReferenceDate: 200))
-        XCTAssertEqual(headers["Authorization"].first, "AWS4-HMAC-SHA256 Credential=MYACCESSKEY/20010101/eu-west-1/sns/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=1d29943055a8ad094239e8de06082100f2426ebbb2c6a5bbcbb04c63e6a3f274")
+        XCTAssertEqual(headers["Authorization"].first, "AWS4-HMAC-SHA256 Credential=MYACCESSKEY/20010101/eu-west-1/sns/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=2271d5b58b667169c9608edbcc5e619d1c4d2dc897d00660aba1d3909dc2189b")
     }
 
     func testSignS3GetURL() {
@@ -134,10 +134,9 @@ final class AWSSignerTests: XCTestCase {
         POST
         /test
         hello=true&item=apple
-        content-type:application/json
         host:localhost
 
-        content-type;host
+        host
         44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         """
         XCTAssertEqual(request, expectedRequest)
@@ -159,11 +158,10 @@ final class AWSSignerTests: XCTestCase {
         POST
         /test
 
-        content-type:application/json
         header:my header
         host:localhost
 
-        content-type;header;host
+        header;host
         44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
         """
         XCTAssertEqual(request, expectedRequest)


### PR DESCRIPTION
Remove content-type, content-length, expect and user-agent from signed headers list.

This is the same as AWS cli does.