### PR TITLE
When a query parameter has no value, output is as `key=`

### DIFF
--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -69,7 +69,7 @@ public struct AWSSigner: _SignerSendable {
                 guard let value1 = $0.value, let value2 = $1.value else { return false }
                 return value1 < value2
             }
-            .map { item in item.value.map { "\(item.name)=\($0.uriEncode())" } ?? item.name }
+            .map { item in item.value.map { "\(item.name)=\($0.uriEncode())" } ?? "\(item.name)=" }
             .joined(separator: "&")
         urlComponents.percentEncodedQuery = urlQueryString
         // S3 requires "+" encoded in the URL

--- a/Tests/SotoSignerV4Tests/AWSSignerTests.swift
+++ b/Tests/SotoSignerV4Tests/AWSSignerTests.swift
@@ -101,6 +101,8 @@ final class AWSSignerTests: XCTestCase {
         XCTAssertEqual(signer.processURL(url: url3), URL(string: "https://test.s3.amazonaws.com?test=hello%20goodbye"))
         let url4 = URL(string: "https://test.s3.amazonaws.com?test=hello&item=orange&item=apple")!
         XCTAssertEqual(signer.processURL(url: url4), URL(string: "https://test.s3.amazonaws.com?item=apple&item=orange&test=hello"))
+        let url5 = URL(string: "https://test.s3.amazonaws.com?item&item=apple")!
+        XCTAssertEqual(signer.processURL(url: url5), URL(string: "https://test.s3.amazonaws.com?item=&item=apple"))
     }
 
     func testSignS3PutWithHeaderURL() {


### PR DESCRIPTION

When a URL query parameter has no value, AWS expects it to be presented as `key=`. processURL did not add the `=` sign.

See https://github.com/soto-project/soto-core/issues/523
