### PR TITLE
Fix stack overflows generated when streaming requests

### DIFF
--- a/Sources/SotoCore/HTTP/S3StreamReader.swift
+++ b/Sources/SotoCore/HTTP/S3StreamReader.swift
@@ -129,7 +129,9 @@ final class S3ChunkedStreamReader: StreamReader {
                 // if there are still bytes left to read then call _fillBuffer again, otherwise succeed with the
                 // contents of the working buffer
                 if self.bytesLeftToRead > 0 {
-                    _fillBuffer()
+                    eventLoop.execute {
+                        _fillBuffer()
+                    }
                 } else {
                     promise.succeed(self.workingBuffer)
                 }


### PR DESCRIPTION
Use `eventLoop.execute` instead of calling function directly. If streamed results are always available as soon as `streamChunks` is called it is the equivalent to a function call which can then mount up and cause a stack overflow