### PR TITLE
Simplify CodeQL file now it's out of Beta

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,16 +6,11 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-  CODEQL_ENABLE_EXPERIMENTAL_FEATURES_SWIFT: true
-
 jobs:
   analyze:
     name: Analyze
     runs-on: macos-latest
     permissions:
-      actions: read
-      contents: read
       security-events: write
 
     strategy:
@@ -37,5 +32,3 @@ jobs:
     
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      with:
-        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
This removes the environment variable as Swift is out of beta so no longer needed. It also removes some permissions that are only required for private repositories.

We could also run this on Linux as CodeQL now supports 5.8 and Linux properly, but I've left it as macOS. Happy to switch it to Linux if it makes it easier (currently in Vapor I've opted for both to catch any issues just in case)