### PR TITLE
Fix ExpiringValue tests

### DIFF
--- a/Tests/SotoCoreTests/Concurrency/ExpiringValueTests.swift
+++ b/Tests/SotoCoreTests/Concurrency/ExpiringValueTests.swift
@@ -47,7 +47,7 @@ final class ExpiringValueTests: XCTestCase {
             try await Task.sleep(nanoseconds: 1000)
             return (1, Date())
         }
-        try await Task.sleep(nanoseconds: 10000)
+        await Task.yield()
         // test it return current value
         XCTAssertEqual(value, 0)
         // test it kicked off a task

--- a/Tests/SotoCoreTests/Credential/RotatingCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/RotatingCredentialProviderTests.swift
@@ -173,6 +173,7 @@ class RotatingCredentialProviderTests: XCTestCase {
         for _ in 0..<iterations {
             _ = try await provider.getCredential(logger: TestEnvironment.logger)
             await Task.yield()
+            await Task.yield()
         }
         XCTAssertEqual(count.load(ordering: .sequentiallyConsistent), 2)
     }


### PR DESCRIPTION
There is a problem with the tests where we are checking an almost expired value in ExpiringValue