### PR TITLE
Import SotoXML as implementation only

### DIFF
--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2022 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -24,7 +24,6 @@ import NIOCore
 import NIOHTTP1
 import NIOTransportServices
 import SotoSignerV4
-import SotoXML
 
 /// Client managing communication with AWS services
 ///

--- a/Sources/SotoCore/Concurrency/EventStream.swift
+++ b/Sources/SotoCore/Concurrency/EventStream.swift
@@ -14,7 +14,6 @@
 
 import Foundation
 import NIOCore
-import SotoXML
 
 /// AsyncSequence of Event stream events
 public struct AWSEventStream<Event: Sendable>: Sendable {

--- a/Sources/SotoCore/Doc/AWSShape+Encoder.swift
+++ b/Sources/SotoCore/Doc/AWSShape+Encoder.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2020 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,7 +14,7 @@
 
 import class Foundation.JSONEncoder
 import NIOCore
-import SotoXML
+@_implementationOnly  import SotoXML
 
 internal extension AWSEncodableShape {
     /// Encode AWSShape as JSON

--- a/Sources/SotoCore/Doc/AWSShape+Encoder.swift
+++ b/Sources/SotoCore/Doc/AWSShape+Encoder.swift
@@ -14,7 +14,7 @@
 
 import class Foundation.JSONEncoder
 import NIOCore
-@_implementationOnly  import SotoXML
+@_implementationOnly import SotoXML
 
 internal extension AWSEncodableShape {
     /// Encode AWSShape as JSON

--- a/Sources/SotoCore/Encoder/EventStreamDecoder.swift
+++ b/Sources/SotoCore/Encoder/EventStreamDecoder.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 import NIOCore
-import SotoXML
+@_implementationOnly import SotoXML
 
 /// Event stream decoder. Decodes top level `:event-type` header and then passes the payload
 /// to another decoder based off the `:content-type` header

--- a/Sources/SotoCore/HTTP/AWSHTTPResponse.swift
+++ b/Sources/SotoCore/HTTP/AWSHTTPResponse.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2020 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -24,7 +24,7 @@ import Logging
 import NIOCore
 import NIOFoundationCompat
 import NIOHTTP1
-import SotoXML
+@_implementationOnly import SotoXML
 
 /// Structure encapsulating an HTTP Response
 public struct AWSHTTPResponse {
@@ -282,7 +282,7 @@ private protocol APIError {
 }
 
 extension XML.Document {
-    public convenience init(buffer: ByteBuffer) throws {
+    internal convenience init(buffer: ByteBuffer) throws {
         let xmlString = String(buffer: buffer)
         try self.init(string: xmlString)
     }

--- a/Sources/SotoCore/Message/Middleware/S3Middleware.swift
+++ b/Sources/SotoCore/Message/Middleware/S3Middleware.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2022 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,7 +14,7 @@
 
 import Crypto
 import Foundation
-import SotoXML
+@_implementationOnly import SotoXML
 
 /// Middleware applied to S3 service
 ///

--- a/Tests/SotoCoreTests/AWSClientTests.swift
+++ b/Tests/SotoCoreTests/AWSClientTests.swift
@@ -23,7 +23,6 @@ import NIOHTTP1
 import NIOPosix
 @testable import SotoCore
 import SotoTestUtils
-import SotoXML
 import XCTest
 
 class AWSClientTests: XCTestCase {

--- a/Tests/SotoCoreTests/AWSResponseTests.swift
+++ b/Tests/SotoCoreTests/AWSResponseTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2022 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/SotoCoreTests/Credential/ConfigFileLoaderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileLoaderTests.swift
@@ -18,7 +18,6 @@ import NIOCore
 import NIOPosix
 @testable import SotoCore
 import SotoTestUtils
-import SotoXML
 import XCTest
 
 class ConfigFileLoadersTests: XCTestCase {

--- a/Tests/SotoCoreTests/TimeStampTests.swift
+++ b/Tests/SotoCoreTests/TimeStampTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2020 the Soto project authors
+// Copyright (c) 2017-2023 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information


### PR DESCRIPTION
SotoXML is an internal module which shouldn't be used outside of SotoCore