### PR TITLE
Require async-http-client 1.18.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.7.2"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.13.1"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.11.2"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.18.0"),
         .package(url: "https://github.com/adam-fowler/jmespath.swift.git", from: "1.0.2"),
     ],
     targets: [


### PR DESCRIPTION
Update to version which resolves https://github.com/swift-server/async-http-client/security/advisories/GHSA-v3r5-pjpm-mwgq
