### PR TITLE
 Use ISO8601DateFormatter instead of DateFormatter

### DIFF
--- a/Sources/SotoCore/Credential/MetaDataCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/MetaDataCredentialProvider.swift
@@ -18,9 +18,8 @@ import AsyncHTTPClient
 #else
 import struct Foundation.Date
 #endif
-import class Foundation.DateFormatter
+import class Foundation.ISO8601DateFormatter
 import class Foundation.JSONDecoder
-import struct Foundation.Locale
 import struct Foundation.TimeInterval
 import struct Foundation.TimeZone
 import struct Foundation.URL
@@ -58,12 +57,7 @@ extension MetaDataClient {
     static func createJSONDecoder() -> JSONDecoder {
         let decoder = JSONDecoder()
         // set JSON decoding strategy for dates
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-        decoder.dateDecodingStrategy = .formatted(dateFormatter)
-
+        decoder.dateDecodingStrategy = .iso8601
         return decoder
     }
 }

--- a/Sources/SotoCore/Credential/MetaDataCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/MetaDataCredentialProvider.swift
@@ -21,7 +21,6 @@ import struct Foundation.Date
 import class Foundation.ISO8601DateFormatter
 import class Foundation.JSONDecoder
 import struct Foundation.TimeInterval
-import struct Foundation.TimeZone
 import struct Foundation.URL
 
 import Logging

--- a/Sources/SotoCore/Encoder/QueryEncoder.swift
+++ b/Sources/SotoCore/Encoder/QueryEncoder.swift
@@ -14,9 +14,7 @@
 
 import struct Foundation.CharacterSet
 import struct Foundation.Date
-import class Foundation.DateFormatter
-import struct Foundation.Locale
-import struct Foundation.TimeZone
+import class Foundation.ISO8601DateFormatter
 
 /// The wrapper struct for encoding Codable classes to Query dictionary
 public struct QueryEncoder {
@@ -394,11 +392,9 @@ extension _QueryEncoder {
         }
     }
 
-    static let dateFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+    static let dateFormatter: ISO8601DateFormatter = {
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withFullDate, .withFullTime, .withFractionalSeconds]
         return dateFormatter
     }()
 }

--- a/Sources/SotoCore/Encoder/RequestContainer.swift
+++ b/Sources/SotoCore/Encoder/RequestContainer.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import struct Foundation.CharacterSet
+import struct Foundation.Date
 import struct Foundation.URL
 import struct Foundation.URLComponents
 
@@ -108,6 +109,12 @@ public class RequestEncodingContainer {
         if let wrappedValue = value.wrappedValue, let string = Coder.string(from: wrappedValue) {
             self.headers.replaceOrAdd(name: key, value: string)
         }
+    }
+
+    /// Write dictionary key value pairs to headers with prefix added to the keys
+    @inlinable
+    public func encodeHeader(_ value: Date, key: String) {
+        self.encodeHeader(HTTPHeaderDateCoder.string(from: value), key: key)
     }
 
     /// Write dictionary key value pairs to headers with prefix added to the keys

--- a/Sources/SotoXML/XMLDecoder.swift
+++ b/Sources/SotoXML/XMLDecoder.swift
@@ -14,11 +14,9 @@
 
 import struct Foundation.Data
 import struct Foundation.Date
-import class Foundation.DateFormatter
-import struct Foundation.Locale
+import class Foundation.ISO8601DateFormatter
 import class Foundation.NSNull
 import class Foundation.NSNumber
-import struct Foundation.TimeZone
 import struct Foundation.URL
 
 /// The wrapper class for decoding Codable classes from XMLNodes
@@ -660,16 +658,10 @@ private class _XMLDecoder: Decoder {
         }
     }
 
-    static let dateFormatters: [DateFormatter] = {
-        var dateFormatters: [DateFormatter] = []
-        let formats = ["yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", "yyyy-MM-dd'T'HH:mm:ss'Z'"]
-        for format in formats {
-            let dateFormatter = DateFormatter()
-            dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-            dateFormatter.dateFormat = format
-            dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
-            dateFormatters.append(dateFormatter)
-        }
+    static let dateFormatters: [ISO8601DateFormatter] = {
+        let dateFormatters: [ISO8601DateFormatter] = [ISO8601DateFormatter(), ISO8601DateFormatter()]
+        dateFormatters[0].formatOptions = [.withFullDate, .withFullTime, .withFractionalSeconds]
+        dateFormatters[1].formatOptions = [.withFullDate, .withFullTime]
         return dateFormatters
     }()
 }

--- a/Sources/SotoXML/XMLEncoder.swift
+++ b/Sources/SotoXML/XMLEncoder.swift
@@ -14,9 +14,7 @@
 
 import struct Foundation.Data
 import struct Foundation.Date
-import class Foundation.DateFormatter
-import struct Foundation.Locale
-import struct Foundation.TimeZone
+import class Foundation.ISO8601DateFormatter
 import struct Foundation.URL
 
 /// The wrapper class for encoding Codable classes to XMLElements
@@ -562,11 +560,9 @@ extension _XMLEncoder {
         }
     }
 
-    static let dateFormatter: DateFormatter = {
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+    static let dateFormatter: ISO8601DateFormatter = {
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withFullDate, .withFullTime, .withFractionalSeconds]
         return dateFormatter
     }()
 }


### PR DESCRIPTION
Also 
- fixed an issue where headers are not output in date time format by default
- Added testHeaderDateEncoding 