### PR TITLE
Hide request/response containers behind @_spi(SotoInternal)

### DIFF
--- a/Sources/SotoCore/Encoder/RequestContainer.swift
+++ b/Sources/SotoCore/Encoder/RequestContainer.swift
@@ -19,6 +19,7 @@ import struct Foundation.URLComponents
 
 /// Request container used during Codable `encode(to:)` that allows for encoding data into
 /// the request that is not part of standard Codable output
+@_spi(SotoInternal)
 public class RequestEncodingContainer {
     @usableFromInline
     var path: String

--- a/Sources/SotoCore/Encoder/ResponseContainer.swift
+++ b/Sources/SotoCore/Encoder/ResponseContainer.swift
@@ -28,6 +28,7 @@ public struct HeaderDecodingError: Error {
 
 /// Response container used during Codable `init(from:)` that allows for extracting data from
 /// the full response and not only its body
+@_spi(SotoInternal)
 public struct ResponseDecodingContainer {
     @usableFromInline
     let response: AWSHTTPResponse

--- a/Tests/SotoCoreTests/AWSClientTests.swift
+++ b/Tests/SotoCoreTests/AWSClientTests.swift
@@ -21,7 +21,7 @@ import NIOCore
 import NIOFoundationCompat
 import NIOHTTP1
 import NIOPosix
-@testable import SotoCore
+@testable @_spi(SotoInternal) import SotoCore
 import SotoTestUtils
 import XCTest
 

--- a/Tests/SotoCoreTests/AWSRequestTests.swift
+++ b/Tests/SotoCoreTests/AWSRequestTests.swift
@@ -19,7 +19,7 @@ import struct Foundation.Data
 #endif
 import NIOCore
 import NIOHTTP1
-@testable import SotoCore
+@testable @_spi(SotoInternal) import SotoCore
 import SotoSignerV4
 import SotoTestUtils
 import SotoXML

--- a/Tests/SotoCoreTests/AWSResponseTests.swift
+++ b/Tests/SotoCoreTests/AWSResponseTests.swift
@@ -14,7 +14,7 @@
 
 import NIOCore
 import NIOHTTP1
-@testable import SotoCore
+@testable @_spi(SotoInternal) import SotoCore
 import SotoTestUtils
 import SotoXML
 import XCTest

--- a/Tests/SotoCoreTests/TimeStampTests.swift
+++ b/Tests/SotoCoreTests/TimeStampTests.swift
@@ -18,7 +18,7 @@
 import struct Foundation.Date
 #endif
 import NIOHTTP1
-@testable import SotoCore
+@testable @_spi(SotoInternal) import SotoCore
 import SotoTestUtils
 import SotoXML
 import XCTest


### PR DESCRIPTION
Thoughts?

This hides public symbols in SotoCore that are required by Soto, but should not really be public to users of Soto