### PR TITLE
Use SotoInternal to hide extensions

### DIFF
--- a/Sources/SotoCore/Middleware/Middleware/EndpointDiscoveryMiddleware.swift
+++ b/Sources/SotoCore/Middleware/Middleware/EndpointDiscoveryMiddleware.swift
@@ -22,7 +22,7 @@ import struct Foundation.TimeInterval
 import struct Foundation.URL
 import Logging
 import NIOHTTP1
-import SotoSignerV4
+@_spi(SotoInternal) import SotoSignerV4
 
 /// Middleware that runs an endpoint discovery function  to set service endpoint
 /// prior to running operation

--- a/Sources/SotoCore/Middleware/Middleware/S3Middleware.swift
+++ b/Sources/SotoCore/Middleware/Middleware/S3Middleware.swift
@@ -14,6 +14,7 @@
 
 import Crypto
 import Foundation
+@_spi(SotoInternal) import SotoSignerV4
 @_implementationOnly import SotoXML
 
 /// Middleware applied to S3 service

--- a/Sources/SotoCore/Middleware/Middleware/TreeHashMiddleware.swift
+++ b/Sources/SotoCore/Middleware/Middleware/TreeHashMiddleware.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
+@_spi(SotoInternal) import SotoSignerV4
 
 let MEGA_BYTE = 1024 * 1024
 

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -433,6 +433,7 @@ extension String {
     static let queryAllowedCharacters = CharacterSet(charactersIn: "/;+").inverted
 }
 
+@_spi(SotoInternal)
 public extension Sequence where Element == UInt8 {
     /// return a hexEncoded string buffer from an array of bytes
     func hexDigest() -> String {
@@ -440,6 +441,7 @@ public extension Sequence where Element == UInt8 {
     }
 }
 
+@_spi(SotoInternal)
 public extension URL {
     /// return URL path, but do not remove the slash at the end if it exists.
     ///


### PR DESCRIPTION
`Sequence.hexDigest` and `URL.pathWithSlash` both extend types we don't own so should not be part of the public interface