### PR TITLE
Add Sendable to AWSShapeOptions

### DIFF
--- a/Sources/SotoCore/Doc/AWSShape.swift
+++ b/Sources/SotoCore/Doc/AWSShape.swift
@@ -225,7 +225,7 @@ public extension AWSEncodableShape {
 public protocol AWSDecodableShape: AWSShape & Decodable {}
 
 /// AWSShape options.
-public struct AWSShapeOptions: OptionSet {
+public struct AWSShapeOptions: OptionSet, Sendable {
     public var rawValue: Int
 
     public init(rawValue: Int) {


### PR DESCRIPTION
In Xcode15.3(now in RC), it shows many warnings of concurrency.


![](https://github.com/soto-project/soto-core/assets/19257572/7f693342-01e0-4526-861a-7c20ab39bfdf)
