### PR TITLE
Add support for AWS_ROLE_ARN environment variables

### DIFF
--- a/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
+++ b/Sources/SotoCore/Credential/ConfigFileCredentialProvider.swift
@@ -92,10 +92,10 @@ final class ConfigFileCredentialProvider: CredentialProviderSelector {
         case .staticCredential(let staticCredential):
             return staticCredential
         case .assumeRole(let roleArn, let sessionName, let region, let sourceCredentialProvider):
-            let request = STSAssumeRoleRequest(roleArn: roleArn, roleSessionName: sessionName)
             let region = region ?? .useast1
             return STSAssumeRoleCredentialProvider(
-                request: request,
+                roleArn: roleArn,
+                roleSessionName: sessionName,
                 credentialProvider: sourceCredentialProvider,
                 region: region,
                 httpClient: context.httpClient,

--- a/Sources/SotoCore/Credential/CredentialProviderError.swift
+++ b/Sources/SotoCore/Credential/CredentialProviderError.swift
@@ -13,20 +13,24 @@
 //===----------------------------------------------------------------------===//
 
 public struct CredentialProviderError: Error, Equatable {
-    enum _CredentialProviderError {
+    enum _CredentialProviderError: Equatable {
         case noProvider
+        case tokenIdFileFailedToLoad
     }
 
     let error: _CredentialProviderError
 
-    public static var noProvider: CredentialProviderError { return .init(error: .noProvider) }
+    public static var noProvider: CredentialProviderError { .init(error: .noProvider) }
+    public static var tokenIdFileFailedToLoad: CredentialProviderError { .init(error: .tokenIdFileFailedToLoad) }
 }
 
 extension CredentialProviderError: CustomStringConvertible {
     public var description: String {
         switch self.error {
         case .noProvider:
-            return "No credential provider found"
+            return "No credential provider found."
+        case .tokenIdFileFailedToLoad:
+            return "WebIdentity token id file failed to load."
         }
     }
 }

--- a/Sources/SotoCore/Credential/StaticCredential+Environment.swift
+++ b/Sources/SotoCore/Credential/StaticCredential+Environment.swift
@@ -14,10 +14,10 @@
 
 import SotoSignerV4
 
-public extension StaticCredential {
+extension StaticCredential {
     /// construct static credentaisl from environment variables `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
     /// and `AWS_SESSION_TOKEN` if it exists
-    static func fromEnvironment() -> StaticCredential? {
+    static func fromEnvironment() -> CredentialProvider? {
         guard let accessKeyId = Environment["AWS_ACCESS_KEY_ID"] else {
             return nil
         }
@@ -25,7 +25,7 @@ public extension StaticCredential {
             return nil
         }
 
-        return .init(
+        return StaticCredential(
             accessKeyId: accessKeyId,
             secretAccessKey: secretAccessKey,
             sessionToken: Environment["AWS_SESSION_TOKEN"]

--- a/Sources/SotoTestUtils/TestUtils.swift
+++ b/Sources/SotoTestUtils/TestUtils.swift
@@ -124,3 +124,16 @@ public enum TestEnvironment {
         return AWSClient.loggingDisabled
     }()
 }
+
+/// Run closure and then run teardown closure once closure has either returned or throw an error
+public func withTeardown<Value>(_ process: () async throws -> Value, teardown: () async -> Void) async throws -> Value {
+    let result: Value
+    do {
+        result = try await process()
+    } catch {
+        await teardown()
+        throw error
+    }
+    await teardown()
+    return result
+}

--- a/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
@@ -59,8 +59,13 @@ class ConfigFileCredentialProviderTests: XCTestCase {
             context: context,
             endpoint: nil
         )
-        XCTAssertTrue(provider is STSAssumeRoleCredentialProvider)
-        XCTAssertEqual((provider as? STSAssumeRoleCredentialProvider)?.request.roleArn, "arn")
+        let stsProvider = try XCTUnwrap(provider as? STSAssumeRoleCredentialProvider)
+        switch stsProvider.request {
+        case .assumeRole(let arn, let sessionName):
+            XCTAssertEqual(arn, "arn")
+            XCTAssertEqual(sessionName, "baz")
+        default: XCTFail()
+        }
 
         try await provider.shutdown()
         try await httpClient.shutdown()

--- a/Tests/SotoCoreTests/Credential/STSAssumeRoleTests.swift
+++ b/Tests/SotoCoreTests/Credential/STSAssumeRoleTests.swift
@@ -70,6 +70,7 @@ class STSAssumeRoleTests: XCTestCase {
         }
         let fileIO = NonBlockingFileIO(threadPool: .singleton)
         let webIdentityToken = "TestThis"
+        // Write token to file referenced by AWS_WEB_IDENTITY_TOKEN_FILE env variable
         try await fileIO.withFileHandle(path: "temp_webidentity_token", mode: .write, flags: .allowFileCreation()) { fileHandle in
             try await fileIO.write(fileHandle: fileHandle, buffer: ByteBuffer(string: webIdentityToken))
         }

--- a/Tests/SotoCoreTests/Credential/StaticCredential+EnvironmentTests.swift
+++ b/Tests/SotoCoreTests/Credential/StaticCredential+EnvironmentTests.swift
@@ -34,13 +34,7 @@ extension Environment {
 }
 
 class StaticCredential_EnvironmentTests: XCTestCase {
-    override func tearDown() {
-        Environment.unset(name: "AWS_ACCESS_KEY_ID")
-        Environment.unset(name: "AWS_SECRET_ACCESS_KEY")
-        Environment.unset(name: "AWS_SESSION_TOKEN")
-    }
-
-    func testSuccess() {
+    func testSuccess() async throws {
         let accessKeyId = "AWSACCESSKEYID"
         let secretAccessKet = "AWSSECRETACCESSKEY"
         let sessionToken = "AWSSESSIONTOKEN"
@@ -48,8 +42,14 @@ class StaticCredential_EnvironmentTests: XCTestCase {
         Environment.set(accessKeyId, for: "AWS_ACCESS_KEY_ID")
         Environment.set(secretAccessKet, for: "AWS_SECRET_ACCESS_KEY")
         Environment.set(sessionToken, for: "AWS_SESSION_TOKEN")
+        defer {
+            Environment.unset(name: "AWS_ACCESS_KEY_ID")
+            Environment.unset(name: "AWS_SECRET_ACCESS_KEY")
+            Environment.unset(name: "AWS_SESSION_TOKEN")
+        }
 
-        let cred = StaticCredential.fromEnvironment()
+        let staticCredentials = StaticCredential.fromEnvironment()
+        let cred = try await staticCredentials?.getCredential(logger: .init(label: #function))
 
         XCTAssertEqual(cred?.accessKeyId, accessKeyId)
         XCTAssertEqual(cred?.secretAccessKey, secretAccessKet)
@@ -62,6 +62,10 @@ class StaticCredential_EnvironmentTests: XCTestCase {
 
         Environment.set(secretAccessKet, for: "AWS_SECRET_ACCESS_KEY")
         Environment.set(sessionToken, for: "AWS_SESSION_TOKEN")
+        defer {
+            Environment.unset(name: "AWS_ACCESS_KEY_ID")
+            Environment.unset(name: "AWS_SECRET_ACCESS_KEY")
+        }
 
         let cred = StaticCredential.fromEnvironment()
 
@@ -74,20 +78,29 @@ class StaticCredential_EnvironmentTests: XCTestCase {
 
         Environment.set(accessKeyId, for: "AWS_ACCESS_KEY_ID")
         Environment.set(sessionToken, for: "AWS_SESSION_TOKEN")
+        defer {
+            Environment.unset(name: "AWS_ACCESS_KEY_ID")
+            Environment.unset(name: "AWS_SECRET_ACCESS_KEY")
+        }
 
         let cred = StaticCredential.fromEnvironment()
 
         XCTAssertNil(cred)
     }
 
-    func testSuccessWithoutSessionToken() {
+    func testSuccessWithoutSessionToken() async throws {
         let accessKeyId = "AWSACCESSKEYID"
         let secretAccessKet = "AWSSECRETACCESSKEY"
 
         Environment.set(accessKeyId, for: "AWS_ACCESS_KEY_ID")
         Environment.set(secretAccessKet, for: "AWS_SECRET_ACCESS_KEY")
+        defer {
+            Environment.unset(name: "AWS_ACCESS_KEY_ID")
+            Environment.unset(name: "AWS_SECRET_ACCESS_KEY")
+        }
 
-        let cred = StaticCredential.fromEnvironment()
+        let staticCredentials = StaticCredential.fromEnvironment()
+        let cred = try await staticCredentials?.getCredential(logger: .init(label: #function))
 
         XCTAssertEqual(cred?.accessKeyId, accessKeyId)
         XCTAssertEqual(cred?.secretAccessKey, secretAccessKet)

--- a/Tests/SotoCoreTests/LoggingTests.swift
+++ b/Tests/SotoCoreTests/LoggingTests.swift
@@ -171,7 +171,7 @@ class LoggingTests: XCTestCase {
                 logger: logger
             )
         } catch {}
-        XCTAssertNotNil(logCollection.filter(metadata: "aws-error-message", with: "No credential provider found").first)
+        XCTAssertNotNil(logCollection.filter(metadata: "aws-error-message", with: "No credential provider found.").first)
     }
 
     func testRequestLogLevel() async throws {


### PR DESCRIPTION
Add support for `AWS_ROLE_ARN`, `AWS_ROLE_SESSION_NAME` and `AWS_WEB_IDENTITY_TOKEN_FILE` environment variables.

This ended up required more change than expected as it required another STS command merged into SotoCore. I have also tidied up a few things along the way.