### PR TITLE
Use HTTPClient.shared now that it is available

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.7.2"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.13.1"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.21.0"),
         .package(url: "https://github.com/adam-fowler/jmespath.swift.git", from: "1.0.2"),
     ],
     targets: [

--- a/Sources/SotoCore/Credential/STSAssumeRole.swift
+++ b/Sources/SotoCore/Credential/STSAssumeRole.swift
@@ -157,7 +157,7 @@ struct STSAssumeRoleCredentialProvider: CredentialProviderWithClient {
         httpClient: AWSHTTPClient,
         endpoint: String? = nil
     ) {
-        self.client = AWSClient(credentialProvider: credentialProvider, httpClientProvider: .shared(httpClient))
+        self.client = AWSClient(credentialProvider: credentialProvider, httpClient: httpClient)
         self.request = .assumeRole(arn: roleArn, sessionName: roleSessionName)
         self.config = AWSServiceConfig(
             region: region,
@@ -180,7 +180,7 @@ struct STSAssumeRoleCredentialProvider: CredentialProviderWithClient {
         endpoint: String? = nil,
         threadPool: NIOThreadPool = .singleton
     ) {
-        self.client = AWSClient(credentialProvider: .empty, httpClientProvider: .shared(httpClient))
+        self.client = AWSClient(credentialProvider: .empty, httpClient: httpClient)
         self.request = .assumeRoleWithWebIdentity(
             arn: roleArn,
             sessionName: roleSessionName,

--- a/Sources/SotoTestUtils/TestUtils.swift
+++ b/Sources/SotoTestUtils/TestUtils.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import AsyncHTTPClient
 import Foundation
 import Logging
 import SotoCore
@@ -37,7 +38,7 @@ public func createAWSClient(
     retryPolicy: RetryPolicyFactory = .noRetry,
     middlewares: AWSMiddlewareProtocol = TestEnvironment.middlewares,
     options: AWSClient.Options = .init(),
-    httpClientProvider: AWSClient.HTTPClientProvider = .createNew,
+    httpClient: AWSHTTPClient = HTTPClient.shared,
     logger: Logger = TestEnvironment.logger
 ) -> AWSClient {
     return AWSClient(
@@ -45,7 +46,7 @@ public func createAWSClient(
         retryPolicy: retryPolicy,
         middleware: middlewares,
         options: options,
-        httpClientProvider: httpClientProvider,
+        httpClient: httpClient,
         logger: logger
     )
 }

--- a/Tests/SotoCoreTests/AWSClientTests.swift
+++ b/Tests/SotoCoreTests/AWSClientTests.swift
@@ -41,15 +41,7 @@ class AWSClientTests: XCTestCase {
         let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
         defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
 
-        let client = createAWSClient(httpClientProvider: .shared(httpClient))
-        try await client.shutdown()
-    }
-
-    func testShutdownWithEventLoop() async throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
-
-        let client = createAWSClient(httpClientProvider: .createNewWithEventLoopGroup(eventLoopGroup))
+        let client = createAWSClient(httpClient: httpClient)
         try await client.shutdown()
     }
 
@@ -71,7 +63,7 @@ class AWSClientTests: XCTestCase {
         )
         let client = createAWSClient(
             credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"),
-            httpClientProvider: .shared(httpClient)
+            httpClient: httpClient
         )
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
@@ -174,13 +166,10 @@ class AWSClientTests: XCTestCase {
             let i: Int64
         }
         do {
-            let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-            defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
             let awsServer = AWSTestServer(serviceProtocol: .json)
             let config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
             let client = createAWSClient(
-                credentialProvider: .empty,
-                httpClientProvider: .createNewWithEventLoopGroup(eventLoopGroup)
+                credentialProvider: .empty
             )
             defer {
                 XCTAssertNoThrow(try client.syncShutdown())
@@ -218,13 +207,10 @@ class AWSClientTests: XCTestCase {
             let data: AWSBase64Data
         }
         do {
-            let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-            defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
             let awsServer = AWSTestServer(serviceProtocol: .json)
             let config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
             let client = createAWSClient(
-                credentialProvider: .empty,
-                httpClientProvider: .createNewWithEventLoopGroup(eventLoopGroup)
+                credentialProvider: .empty
             )
             defer {
                 XCTAssertNoThrow(try client.syncShutdown())
@@ -288,7 +274,7 @@ class AWSClientTests: XCTestCase {
         let awsServer = AWSTestServer(serviceProtocol: .json)
         let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
         let config = createServiceConfig(endpoint: awsServer.address)
-        let client = createAWSClient(credentialProvider: .empty, httpClientProvider: .shared(httpClient))
+        let client = createAWSClient(credentialProvider: .empty, httpClient: httpClient)
         defer {
             XCTAssertNoThrow(try awsServer.stop())
             XCTAssertNoThrow(try client.syncShutdown())
@@ -304,7 +290,7 @@ class AWSClientTests: XCTestCase {
         let awsServer = AWSTestServer(serviceProtocol: .json)
         let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
         let config = createServiceConfig(service: "s3", endpoint: awsServer.address)
-        let client = createAWSClient(credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"), httpClientProvider: .shared(httpClient))
+        let client = createAWSClient(credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"), httpClient: httpClient)
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
             XCTAssertNoThrow(try awsServer.stop())
@@ -336,7 +322,7 @@ class AWSClientTests: XCTestCase {
         let awsServer = AWSTestServer(serviceProtocol: .json)
         let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
         let config = createServiceConfig(endpoint: awsServer.address)
-        let client = createAWSClient(credentialProvider: .empty, httpClientProvider: .shared(httpClient))
+        let client = createAWSClient(credentialProvider: .empty, httpClient: httpClient)
         defer {
             // ignore error
             try? awsServer.stop()
@@ -384,7 +370,7 @@ class AWSClientTests: XCTestCase {
         let awsServer = AWSTestServer(serviceProtocol: .json)
         let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
         let config = createServiceConfig(endpoint: awsServer.address)
-        let client = createAWSClient(credentialProvider: .empty, httpClientProvider: .shared(httpClient))
+        let client = createAWSClient(credentialProvider: .empty, httpClient: httpClient)
         defer {
             XCTAssertNoThrow(try awsServer.stop())
             XCTAssertNoThrow(try client.syncShutdown())
@@ -423,7 +409,7 @@ class AWSClientTests: XCTestCase {
             let httpClientConfig = AsyncHTTPClient.HTTPClient.Configuration(redirectConfiguration: .init(.disallow))
             let httpClient = AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .singleton, configuration: httpClientConfig)
             let config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
-            let client = createAWSClient(credentialProvider: .empty, httpClientProvider: .shared(httpClient))
+            let client = createAWSClient(credentialProvider: .empty, httpClient: httpClient)
             defer {
                 XCTAssertNoThrow(try awsServer.stop())
                 XCTAssertNoThrow(try client.syncShutdown())
@@ -450,7 +436,7 @@ class AWSClientTests: XCTestCase {
             let httpClient = AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .singleton)
             let awsServer = AWSTestServer(serviceProtocol: .json)
             let config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
-            let client = createAWSClient(credentialProvider: .empty, retryPolicy: .exponential(base: .milliseconds(200)), httpClientProvider: .shared(httpClient))
+            let client = createAWSClient(credentialProvider: .empty, retryPolicy: .exponential(base: .milliseconds(200)), httpClient: httpClient)
             defer {
                 XCTAssertNoThrow(try awsServer.stop())
                 XCTAssertNoThrow(try client.syncShutdown())
@@ -489,7 +475,7 @@ class AWSClientTests: XCTestCase {
             let httpClient = AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .singleton)
             let awsServer = AWSTestServer(serviceProtocol: .json)
             let config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
-            let client = createAWSClient(credentialProvider: .empty, retryPolicy: .jitter(), httpClientProvider: .shared(httpClient))
+            let client = createAWSClient(credentialProvider: .empty, retryPolicy: .jitter(), httpClient: httpClient)
             defer {
                 XCTAssertNoThrow(try awsServer.stop())
                 XCTAssertNoThrow(try client.syncShutdown())
@@ -547,7 +533,7 @@ class AWSClientTests: XCTestCase {
             let httpClient = AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
             defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
             let config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: serverAddress)
-            let client = createAWSClient(credentialProvider: .empty, retryPolicy: .init(retryPolicy: retryPolicy), httpClientProvider: .shared(httpClient))
+            let client = createAWSClient(credentialProvider: .empty, retryPolicy: .init(retryPolicy: retryPolicy), httpClient: httpClient)
             defer { XCTAssertNoThrow(try client.syncShutdown()) }
             async let responseTask: Void = client.execute(
                 operation: "test",
@@ -583,7 +569,7 @@ class AWSClientTests: XCTestCase {
             let httpClient = AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .singleton)
             let awsServer = AWSTestServer(serviceProtocol: .json)
             let config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: awsServer.address)
-            let client = createAWSClient(credentialProvider: .empty, retryPolicy: .jitter(), httpClientProvider: .shared(httpClient))
+            let client = createAWSClient(credentialProvider: .empty, retryPolicy: .jitter(), httpClient: httpClient)
             defer {
                 XCTAssertNoThrow(try awsServer.stop())
                 XCTAssertNoThrow(try client.syncShutdown())
@@ -617,7 +603,7 @@ class AWSClientTests: XCTestCase {
             let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
             let awsServer = AWSTestServer(serviceProtocol: .json)
             let config = createServiceConfig(endpoint: awsServer.address)
-            let client = createAWSClient(credentialProvider: .empty, httpClientProvider: .shared(httpClient))
+            let client = createAWSClient(credentialProvider: .empty, httpClient: httpClient)
             defer {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())
@@ -665,7 +651,7 @@ class AWSClientTests: XCTestCase {
             let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 5)
             let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup))
             let config = createServiceConfig(endpoint: awsServer.address)
-            let client = createAWSClient(credentialProvider: .empty, httpClientProvider: .shared(httpClient))
+            let client = createAWSClient(credentialProvider: .empty, httpClient: httpClient)
             defer {
                 XCTAssertNoThrow(try client.syncShutdown())
                 XCTAssertNoThrow(try httpClient.syncShutdown())

--- a/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/ConfigFileCredentialProviderTests.swift
@@ -249,7 +249,7 @@ class ConfigFileCredentialProviderTests: XCTestCase {
                 context: context,
                 endpoint: testServer.address
             )
-        }, httpClientProvider: .shared(httpClient))
+        }, httpClient: httpClient)
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
 
         // Retrieve credentials

--- a/Tests/SotoCoreTests/Credential/STSAssumeRoleTests.swift
+++ b/Tests/SotoCoreTests/Credential/STSAssumeRoleTests.swift
@@ -28,8 +28,6 @@ class STSAssumeRoleTests: XCTestCase {
             secretAccessKey: "STSSECRETACCESSKEY",
             sessionToken: "STSSESSIONTOKEN"
         )
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { XCTAssertNoThrow(try elg.syncShutdownGracefully()) }
         let testServer = AWSTestServer(serviceProtocol: .xml)
         defer { XCTAssertNoThrow(try testServer.stop()) }
         let client = AWSClient(
@@ -40,7 +38,6 @@ class STSAssumeRoleTests: XCTestCase {
                 region: .useast1,
                 endpoint: testServer.address
             ),
-            httpClientProvider: .createNewWithEventLoopGroup(elg),
             logger: TestEnvironment.logger
         )
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
@@ -75,13 +72,10 @@ class STSAssumeRoleTests: XCTestCase {
             try await fileIO.write(fileHandle: fileHandle, buffer: ByteBuffer(string: webIdentityToken))
         }
         try await withTeardown {
-            let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-            defer { XCTAssertNoThrow(try elg.syncShutdownGracefully()) }
             let testServer = AWSTestServer(serviceProtocol: .xml)
             defer { XCTAssertNoThrow(try testServer.stop()) }
             let client = AWSClient(
                 credentialProvider: .environment(endpoint: testServer.address),
-                httpClientProvider: .createNewWithEventLoopGroup(elg),
                 logger: TestEnvironment.logger
             )
             defer { XCTAssertNoThrow(try client.syncShutdown()) }
@@ -118,11 +112,8 @@ class STSAssumeRoleTests: XCTestCase {
             Environment.unset(name: "AWS_ROLE_SESSION_NAME")
             Environment.unset(name: "AWS_WEB_IDENTITY_TOKEN_FILE")
         }
-        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { XCTAssertNoThrow(try elg.syncShutdownGracefully()) }
         let client = AWSClient(
             credentialProvider: .environment(),
-            httpClientProvider: .createNewWithEventLoopGroup(elg),
             logger: TestEnvironment.logger
         )
         defer { XCTAssertNoThrow(try client.syncShutdown()) }

--- a/Tests/SotoCoreTests/EndpointDiscoveryTests.swift
+++ b/Tests/SotoCoreTests/EndpointDiscoveryTests.swift
@@ -111,7 +111,7 @@ final class EndpointDiscoveryTests: XCTestCase {
         guard ProcessInfo.processInfo.environment["CI"] == nil else { return }
         #endif
         let awsServer = AWSTestServer(serviceProtocol: .restjson)
-        let client = AWSClient(credentialProvider: .empty, httpClientProvider: .createNew)
+        let client = AWSClient(credentialProvider: .empty)
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
             XCTAssertNoThrow(try awsServer.stop())
@@ -140,7 +140,7 @@ final class EndpointDiscoveryTests: XCTestCase {
         guard ProcessInfo.processInfo.environment["CI"] == nil else { return }
         #endif
         let awsServer = AWSTestServer(serviceProtocol: .json)
-        let client = AWSClient(credentialProvider: .empty, httpClientProvider: .createNew)
+        let client = AWSClient(credentialProvider: .empty)
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
             XCTAssertNoThrow(try awsServer.stop())
@@ -172,7 +172,7 @@ final class EndpointDiscoveryTests: XCTestCase {
         guard ProcessInfo.processInfo.environment["CI"] == nil else { return }
         #endif
         let awsServer = AWSTestServer(serviceProtocol: .json)
-        let client = AWSClient(credentialProvider: .empty, httpClientProvider: .createNew)
+        let client = AWSClient(credentialProvider: .empty)
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
             XCTAssertNoThrow(try awsServer.stop())
@@ -201,7 +201,7 @@ final class EndpointDiscoveryTests: XCTestCase {
         guard ProcessInfo.processInfo.environment["CI"] == nil else { return }
         #endif
         let awsServer = AWSTestServer(serviceProtocol: .json)
-        let client = AWSClient(credentialProvider: .empty, httpClientProvider: .createNew)
+        let client = AWSClient(credentialProvider: .empty)
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
             XCTAssertNoThrow(try awsServer.stop())

--- a/Tests/SotoCoreTests/LoggingTests.swift
+++ b/Tests/SotoCoreTests/LoggingTests.swift
@@ -26,7 +26,6 @@ class LoggingTests: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop()) }
         let client = AWSClient(
             credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"),
-            httpClientProvider: .createNew,
             logger: logger
         )
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
@@ -67,7 +66,6 @@ class LoggingTests: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop()) }
         let client = AWSClient(
             credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"),
-            httpClientProvider: .createNew,
             logger: logger
         )
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
@@ -102,7 +100,6 @@ class LoggingTests: XCTestCase {
         let client = AWSClient(
             credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"),
             options: .init(requestLogLevel: .debug, errorLogLevel: .info),
-            httpClientProvider: .createNew,
             logger: logger
         )
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
@@ -129,7 +126,6 @@ class LoggingTests: XCTestCase {
         defer { XCTAssertNoThrow(try server.stop()) }
         let client = AWSClient(
             credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"),
-            httpClientProvider: .createNew,
             logger: logger
         )
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
@@ -184,7 +180,6 @@ class LoggingTests: XCTestCase {
         let client = AWSClient(
             credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"),
             options: .init(requestLogLevel: .trace),
-            httpClientProvider: .createNew,
             logger: logger
         )
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
@@ -218,7 +213,6 @@ class LoggingTests: XCTestCase {
         let client = AWSClient(
             credentialProvider: .static(accessKeyId: "foo", secretAccessKey: "bar"),
             middleware: AWSLoggingMiddleware(logger: logger, logLevel: .info),
-            httpClientProvider: .createNew,
             logger: logger
         )
         defer { XCTAssertNoThrow(try client.syncShutdown()) }

--- a/Tests/SotoCoreTests/PaginateTests.swift
+++ b/Tests/SotoCoreTests/PaginateTests.swift
@@ -26,25 +26,19 @@ final class PaginateTests: XCTestCase, @unchecked Sendable {
     }
 
     var awsServer: AWSTestServer!
-    var eventLoopGroup: EventLoopGroup!
-    var httpClient: HTTPClient!
     var client: AWSClient!
     var config: AWSServiceConfig!
 
     override func setUp() {
         // create server and client
         self.awsServer = AWSTestServer(serviceProtocol: .json)
-        self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 3)
-        self.httpClient = AsyncHTTPClient.HTTPClient(eventLoopGroupProvider: .shared(self.eventLoopGroup))
         self.config = createServiceConfig(serviceProtocol: .json(version: "1.1"), endpoint: self.awsServer.address)
-        self.client = createAWSClient(credentialProvider: .empty, retryPolicy: .noRetry, httpClientProvider: .shared(self.httpClient))
+        self.client = createAWSClient(credentialProvider: .empty, retryPolicy: .noRetry)
     }
 
     override func tearDown() {
         XCTAssertNoThrow(try self.awsServer.stop())
         XCTAssertNoThrow(try self.client.syncShutdown())
-        XCTAssertNoThrow(try self.httpClient.syncShutdown())
-        XCTAssertNoThrow(try self.eventLoopGroup.syncShutdownGracefully())
     }
 
     // test structures/functions

--- a/Tests/SotoCoreTests/TracingTests.swift
+++ b/Tests/SotoCoreTests/TracingTests.swift
@@ -36,8 +36,6 @@ final class TracingTests: XCTestCase {
         }
         InstrumentationSystem.bootstrapInternal(tracer)
 
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
         let awsServer = AWSTestServer(serviceProtocol: .json)
         let config = createServiceConfig(
             service: "TestService",
@@ -46,8 +44,7 @@ final class TracingTests: XCTestCase {
             middlewares: AWSTracingMiddleware()
         )
         let client = createAWSClient(
-            credentialProvider: .empty,
-            httpClientProvider: .createNewWithEventLoopGroup(eventLoopGroup)
+            credentialProvider: .empty
         )
         defer {
             XCTAssertNoThrow(try client.syncShutdown())


### PR DESCRIPTION
Replace the `HTTPClientProvider` in `init` with a `AWSHTTPClient` protocol and default it to `HTTPClient.shared`.

@weissi Given your concern, this is the change I wanted to make. It now means AWSClient is not managing an `HTTPClient`.