### PR TITLE
Add support for S3 arn based access points

### DIFF
--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -186,6 +186,7 @@ public final class AWSClient: Sendable {
             case waiterFailed
             case waiterTimeout
             case failedToAccessPayload
+            case invalidARN
         }
 
         let error: Error
@@ -202,6 +203,8 @@ public final class AWSClient: Sendable {
         public static var waiterTimeout: ClientError { .init(error: .waiterTimeout) }
         /// Failed to access payload while building request
         public static var failedToAccessPayload: ClientError { .init(error: .failedToAccessPayload) }
+        /// ARN provided to client is invalid
+        public static var invalidARN: ClientError { .init(error: .invalidARN) }
     }
 
     /// Additional options
@@ -550,6 +553,8 @@ extension AWSClient.ClientError: CustomStringConvertible {
             return "Waiter failed to complete in time allocated"
         case .failedToAccessPayload:
             return "Failed to access payload while building request for AWS"
+        case .invalidARN:
+            return "ARN provided to the client was invalid"
         }
     }
 }

--- a/Sources/SotoCore/AWSServiceConfig.swift
+++ b/Sources/SotoCore/AWSServiceConfig.swift
@@ -182,8 +182,6 @@ public final class AWSServiceConfig {
     /// Service config parameters you can patch
     public struct Patch {
         let region: Region?
-        let serviceIdentifier: String?
-        let signingName: String?
         let endpoint: String?
         let middleware: AWSMiddlewareProtocol?
         let timeout: TimeAmount?
@@ -192,8 +190,6 @@ public final class AWSServiceConfig {
 
         init(
             region: Region? = nil,
-            serviceIdentifier: String? = nil,
-            signingName: String? = nil,
             endpoint: String? = nil,
             middleware: AWSMiddlewareProtocol? = nil,
             timeout: TimeAmount? = nil,
@@ -201,8 +197,6 @@ public final class AWSServiceConfig {
             options: AWSServiceConfig.Options? = nil
         ) {
             self.region = region
-            self.serviceIdentifier = serviceIdentifier
-            self.signingName = signingName
             self.endpoint = endpoint
             self.middleware = middleware
             self.timeout = timeout
@@ -221,8 +215,6 @@ public final class AWSServiceConfig {
     /// - Returns: New version of the service
     public func with(
         region: Region? = nil,
-        serviceIdentifier: String? = nil,
-        signingName: String? = nil,
         middleware: AWSMiddlewareProtocol? = nil,
         timeout: TimeAmount? = nil,
         byteBufferAllocator: ByteBufferAllocator? = nil,
@@ -231,8 +223,6 @@ public final class AWSServiceConfig {
         self.with(
             patch: .init(
                 region: region,
-                serviceIdentifier: serviceIdentifier,
-                signingName: signingName,
                 middleware: middleware,
                 timeout: timeout,
                 byteBufferAllocator: byteBufferAllocator,
@@ -310,8 +300,8 @@ public final class AWSServiceConfig {
     ) {
         self.region = patch.region ?? service.region
         self.options = patch.options ?? service.options
-        self.serviceIdentifier = patch.serviceIdentifier ?? service.serviceIdentifier
-        self.signingName = patch.signingName ?? patch.serviceIdentifier ?? service.signingName
+        self.serviceIdentifier = service.serviceIdentifier
+        self.signingName = service.signingName
 
         if let endpoint = patch.endpoint {
             self.endpoint = endpoint

--- a/Sources/SotoCore/AWSServiceConfig.swift
+++ b/Sources/SotoCore/AWSServiceConfig.swift
@@ -182,6 +182,8 @@ public final class AWSServiceConfig {
     /// Service config parameters you can patch
     public struct Patch {
         let region: Region?
+        let serviceIdentifier: String?
+        let signingName: String?
         let endpoint: String?
         let middleware: AWSMiddlewareProtocol?
         let timeout: TimeAmount?
@@ -190,6 +192,8 @@ public final class AWSServiceConfig {
 
         init(
             region: Region? = nil,
+            serviceIdentifier: String? = nil,
+            signingName: String? = nil,
             endpoint: String? = nil,
             middleware: AWSMiddlewareProtocol? = nil,
             timeout: TimeAmount? = nil,
@@ -197,6 +201,8 @@ public final class AWSServiceConfig {
             options: AWSServiceConfig.Options? = nil
         ) {
             self.region = region
+            self.serviceIdentifier = serviceIdentifier
+            self.signingName = signingName
             self.endpoint = endpoint
             self.middleware = middleware
             self.timeout = timeout
@@ -215,6 +221,8 @@ public final class AWSServiceConfig {
     /// - Returns: New version of the service
     public func with(
         region: Region? = nil,
+        serviceIdentifier: String? = nil,
+        signingName: String? = nil,
         middleware: AWSMiddlewareProtocol? = nil,
         timeout: TimeAmount? = nil,
         byteBufferAllocator: ByteBufferAllocator? = nil,
@@ -223,6 +231,8 @@ public final class AWSServiceConfig {
         self.with(
             patch: .init(
                 region: region,
+                serviceIdentifier: serviceIdentifier,
+                signingName: signingName,
                 middleware: middleware,
                 timeout: timeout,
                 byteBufferAllocator: byteBufferAllocator,
@@ -298,8 +308,10 @@ public final class AWSServiceConfig {
         service: AWSServiceConfig,
         with patch: Patch
     ) {
-        let region = patch.region ?? service.region
-        let options = patch.options ?? service.options
+        self.region = patch.region ?? service.region
+        self.options = patch.options ?? service.options
+        self.serviceIdentifier = patch.serviceIdentifier ?? service.serviceIdentifier
+        self.signingName = patch.signingName ?? patch.serviceIdentifier ?? service.signingName
 
         if let endpoint = patch.endpoint {
             self.endpoint = endpoint
@@ -308,9 +320,9 @@ public final class AWSServiceConfig {
                 patch.endpoint
                 ?? Self.getEndpoint(
                     endpoint: service.providedEndpoint,
-                    region: region,
-                    serviceIdentifier: service.serviceIdentifier,
-                    options: options,
+                    region: self.region,
+                    serviceIdentifier: self.serviceIdentifier,
+                    options: self.options,
                     serviceEndpoints: service.serviceEndpoints,
                     partitionEndpoints: service.partitionEndpoints,
                     variantEndpoints: service.variantEndpoints
@@ -318,13 +330,9 @@ public final class AWSServiceConfig {
         } else {
             self.endpoint = service.endpoint
         }
-        self.region = region
-        self.options = options
 
         self.amzTarget = service.amzTarget
         self.serviceName = service.serviceName
-        self.serviceIdentifier = service.serviceIdentifier
-        self.signingName = service.signingName
         self.serviceProtocol = service.serviceProtocol
         self.apiVersion = service.apiVersion
         self.providedEndpoint = service.providedEndpoint

--- a/Sources/SotoCore/Doc/ARN.swift
+++ b/Sources/SotoCore/Doc/ARN.swift
@@ -13,6 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 /// Amazon Resource Name (ARN). A unique identifier assigned to AWS resource
+///
+/// Comes in one of the following forms
+/// - arn:partition:service:region:account-id:resource-id
+/// - arn:partition:service:region:account-id:resource-type/resource-id
+/// - arn:partition:service:region:account-id:resource-type:resource-id
 public struct ARN {
     public init?<S: StringProtocol>(string: S) where S.SubSequence == Substring {
         let split = string.split(separator: ":", omittingEmptySubsequences: false)

--- a/Sources/SotoCore/Doc/ARN.swift
+++ b/Sources/SotoCore/Doc/ARN.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2024 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+struct ARN {
+    init?<S: StringProtocol>(string: S) where S.SubSequence == Substring {
+        let split = string.split(separator: ":")
+        guard split.count >= 6 else { return nil }
+        guard split[0] == "arn" else { return nil }
+        self.partition = split[1]
+        self.service = split[2]
+        self.region = split[3].count > 0 ? Region(rawValue: String(split[3])) : nil
+        self.accountId = split[4].count > 0 ? split[4] : nil
+        if split.count == 6 {
+            let resourceSplit = split[5].split(separator: "/", maxSplits: 1)
+            if resourceSplit.count == 1 {
+                self.resourceType = nil
+                self.resourceId = resourceSplit[0]
+            } else {
+                self.resourceType = resourceSplit[0]
+                self.resourceId = resourceSplit[1]
+            }
+        } else if split.count == 7 {
+            self.resourceType = split[5]
+            self.resourceId = split[6]
+        } else {
+            return nil
+        }
+    }
+
+    let partition: Substring
+    let service: Substring
+    let region: Region?
+    let accountId: Substring?
+    let resourceId: Substring
+    let resourceType: Substring?
+}

--- a/Sources/SotoCore/Doc/ARN.swift
+++ b/Sources/SotoCore/Doc/ARN.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+/// Amazon Resource Name (ARN). A unique identifier assigned to AWS resource
 public struct ARN {
     public init?<S: StringProtocol>(string: S) where S.SubSequence == Substring {
         let split = string.split(separator: ":", omittingEmptySubsequences: false)

--- a/Sources/SotoCore/Middleware/Middleware.swift
+++ b/Sources/SotoCore/Middleware/Middleware.swift
@@ -15,7 +15,7 @@
 import Logging
 
 /// Context object sent to `AWSMiddlewareProtocol` `handle` functions
-public struct AWSMiddlewareContext {
+public struct AWSMiddlewareContext: Sendable {
     public var operation: String
     public var serviceConfig: AWSServiceConfig
     public var logger: Logger

--- a/Sources/SotoCore/Middleware/Middleware/S3Middleware.swift
+++ b/Sources/SotoCore/Middleware/Middleware/S3Middleware.swift
@@ -37,103 +37,161 @@ internal import SotoXML
 /// - Creates error body for notFound responses to HEAD requests
 public struct S3Middleware: AWSMiddlewareProtocol {
     public func handle(_ request: AWSHTTPRequest, context: AWSMiddlewareContext, next: AWSMiddlewareNextHandler) async throws -> AWSHTTPResponse {
-        var request = request
-        var context = context
 
-        try self.virtualAddressFixup(request: &request, context: &context)
-        self.createBucketFixup(request: &request, context: context)
-        if !context.serviceConfig.options.contains(.s3Disable100Continue) {
-            self.expect100Continue(request: &request)
-        }
-
-        do {
-            var response = try await next(request, context)
-            if context.operation == "GetBucketLocation" {
-                self.getBucketLocationResponseFixup(response: &response)
+        try await self.handleVirtualAddressFixup(request, context: context) { request, context in
+            var request = request
+            self.createBucketFixup(request: &request, context: context)
+            if !context.serviceConfig.options.contains(.s3Disable100Continue) {
+                self.expect100Continue(request: &request)
             }
-            return response
-        } catch let error as AWSRawError {
-            let newError = self.fixupRawError(error: error, context: context)
-            throw newError
+
+            do {
+                var response = try await next(request, context)
+                if context.operation == "GetBucketLocation" {
+                    self.getBucketLocationResponseFixup(response: &response)
+                }
+                return response
+            } catch let error as AWSRawError {
+                let newError = self.fixupRawError(error: error, context: context)
+                throw newError
+            }
         }
     }
 
     public init() {}
 
-    func virtualAddressFixup(request: inout AWSHTTPRequest, context: inout AWSMiddlewareContext) throws {
-        /// process URL into form ${bucket}.s3.amazon.com
-        let paths = request.url.path.split(separator: "/", omittingEmptySubsequences: true)
-        if let bucket = paths.first {
-            guard var host = request.url.host else { return }
-            if let port = request.url.port {
-                host = "\(host):\(port)"
-            }
-            var urlPath: String
-            var urlHost: String
-            let isAmazonUrl = host.hasSuffix("amazonaws.com")
-
-            var hostComponents = host.split(separator: ".")
-            if isAmazonUrl, context.serviceConfig.options.contains(.s3UseTransferAcceleratedEndpoint) {
-                if let s3Index = hostComponents.firstIndex(where: { $0 == "s3" }) {
-                    var s3 = "s3"
-                    s3 += "-accelerate"
-                    // assume next host component is region
-                    let regionIndex = s3Index + 1
-                    hostComponents.remove(at: regionIndex)
-                    hostComponents[s3Index] = Substring(s3)
-                    host = hostComponents.joined(separator: ".")
-                }
-            }
-
-            // Is bucket an ARN
-            if bucket.hasPrefix("arn:") {
-                guard let arn = ARN(string: bucket),
-                    let resourceType = arn.resourceType,
-                    let region = arn.region,
-                    let accountId = arn.accountId
-                else {
-                    throw AWSClient.ClientError.invalidARN
-                }
-                guard resourceType == "accesspoint", arn.service == "s3-object-lambda" || arn.service == "s3-outposts" else {
-                    throw AWSClient.ClientError.invalidARN
-                }
-                urlPath = "/"
-                // https://tutorial-object-lambda-accesspoint-123456789012.s3-object-lambda.us-west-2.amazonaws.com:443
-                urlHost = "https://\(arn.resourceId)-\(resourceType)-\(accountId).\(arn.service).\(region).amazonaws.com"
-
-                // if host name contains amazonaws.com and bucket name doesn't contain a period do virtual address look up
-            } else if isAmazonUrl || context.serviceConfig.options.contains(.s3ForceVirtualHost), !bucket.contains(".") {
-                let pathsWithoutBucket = paths.dropFirst()  // bucket
-                urlPath = pathsWithoutBucket.joined(separator: "/")
-
-                if hostComponents.first == bucket {
-                    // Bucket name is part of host. No need to append bucket
-                    urlHost = host
-                } else {
-                    urlHost = "\(bucket).\(host)"
-                }
-            } else {
-                urlPath = paths.joined(separator: "/")
-                urlHost = host
-            }
-            // add trailing "/" back if it was present, no need to check for single slash path here
-            if request.url.pathWithSlash.hasSuffix("/") {
-                urlPath += "/"
-            }
-            // add percent encoding back into path as converting from URL to String has removed it
-            let percentEncodedUrlPath = Self.urlEncodePath(urlPath)
-            var urlString = "\(request.url.scheme ?? "https")://\(urlHost)/\(percentEncodedUrlPath)"
-            if let query = request.url.query {
-                urlString += "?\(query)"
-            }
-            request.url = URL(string: urlString)!
+    func handleVirtualAddressFixup(
+        _ request: AWSHTTPRequest,
+        context: AWSMiddlewareContext,
+        next: AWSMiddlewareNextHandler
+    ) async throws -> AWSHTTPResponse {
+        if request.url.path.hasPrefix("/arn:") {
+            return try await handleARNBucket(request, context: context, next: next)
         }
+        /// process URL into form ${bucket}.s3.amazon.com
+        let paths = request.url.path.split(separator: "/", maxSplits: 2, omittingEmptySubsequences: false).dropFirst()
+        guard let bucket = paths.first, var host = request.url.host else { return try await next(request, context) }
+
+        if let port = request.url.port {
+            host = "\(host):\(port)"
+        }
+        var urlPath: String
+        var urlHost: String
+        let isAmazonUrl = host.hasSuffix("amazonaws.com")
+
+        var hostComponents = host.split(separator: ".")
+        if isAmazonUrl, context.serviceConfig.options.contains(.s3UseTransferAcceleratedEndpoint) {
+            if let s3Index = hostComponents.firstIndex(where: { $0 == "s3" }) {
+                var s3 = "s3"
+                s3 += "-accelerate"
+                // assume next host component is region
+                let regionIndex = s3Index + 1
+                hostComponents.remove(at: regionIndex)
+                hostComponents[s3Index] = Substring(s3)
+                host = hostComponents.joined(separator: ".")
+            }
+        }
+
+        // Is bucket an ARN
+        if bucket.hasPrefix("arn:") {
+            guard let arn = ARN(string: bucket),
+                let resourceType = arn.resourceType,
+                let region = arn.region,
+                let accountId = arn.accountId
+            else {
+                throw AWSClient.ClientError.invalidARN
+            }
+            guard resourceType == "accesspoint", arn.service == "s3-object-lambda" || arn.service == "s3-outposts" else {
+                throw AWSClient.ClientError.invalidARN
+            }
+            urlPath = "/"
+            // https://tutorial-object-lambda-accesspoint-123456789012.s3-object-lambda.us-west-2.amazonaws.com:443
+            urlHost = "\(arn.resourceId)-\(resourceType)-\(accountId).\(arn.service).\(region).amazonaws.com"
+
+            // if host name contains amazonaws.com and bucket name doesn't contain a period do virtual address look up
+        } else if isAmazonUrl || context.serviceConfig.options.contains(.s3ForceVirtualHost), !bucket.contains(".") {
+            let pathsWithoutBucket = paths.dropFirst()  // bucket
+            urlPath = pathsWithoutBucket.first.flatMap { String($0) } ?? ""  //pathsWithoutBucket.joined(separator: "/")
+
+            if hostComponents.first == bucket {
+                // Bucket name is part of host. No need to append bucket
+                urlHost = host
+            } else {
+                urlHost = "\(bucket).\(host)"
+            }
+        } else {
+            urlPath = paths.joined(separator: "/")
+            urlHost = host
+        }
+        let request = Self.updateRequestURL(request, host: urlHost, path: urlPath)
+        return try await next(request, context)
+    }
+
+    ///  Handle bucket names in the form of an ARN
+    /// - Parameters:
+    ///   - request: request
+    ///   - context: request context
+    ///   - next: next handler
+    /// - Returns: returns response from next handler
+    func handleARNBucket(
+        _ request: AWSHTTPRequest,
+        context: AWSMiddlewareContext,
+        next: AWSMiddlewareNextHandler
+    ) async throws -> AWSHTTPResponse {
+        guard let arn = ARN(string: request.url.path.dropFirst()),
+            let resourceType = arn.resourceType,
+            let accountId = arn.accountId
+        else {
+            throw AWSClient.ClientError.invalidARN
+        }
+        let region = arn.region ?? context.serviceConfig.region
+        guard resourceType == "accesspoint", arn.service == "s3-object-lambda" || arn.service == "s3-outposts" || arn.service == "s3" else {
+            throw AWSClient.ClientError.invalidARN
+        }
+
+        // extract bucket and path from ARN
+        let resourceIDSplit = arn.resourceId.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+        guard let bucket = resourceIDSplit.first else { throw AWSClient.ClientError.invalidARN }
+        let path = String(resourceIDSplit.dropFirst().first ?? "")
+        let urlHost = "\(bucket)-\(accountId).\(arn.service).\(region).amazonaws.com"
+        let request = Self.updateRequestURL(request, host: urlHost, path: path)
+
+        // if service isn't S3 or arn region is different from the current config then build a new AWSServiceConfig
+        if arn.service != "s3" || arn.region != context.serviceConfig.region {
+            var context = context
+            context.serviceConfig = context.serviceConfig.with(region: region, serviceIdentifier: String(arn.service))
+            return try await next(request, context)
+        }
+        return try await next(request, context)
+    }
+
+    ///  Update request with new host and path
+    /// - Parameters:
+    ///   - request: request
+    ///   - host: new host name
+    ///   - path: new path
+    /// - Returns: new request
+    static func updateRequestURL(_ request: AWSHTTPRequest, host: some StringProtocol, path: String) -> AWSHTTPRequest {
+        var path = path
+        // add trailing "/" back if it was present, no need to check for single slash path here
+        if request.url.pathWithSlash.hasSuffix("/") {
+            path += "/"
+        }
+        // add percent encoding back into path as converting from URL to String has removed it
+        let percentEncodedUrlPath = Self.urlEncodePath(path)
+        var urlString = "\(request.url.scheme ?? "https")://\(host)/\(percentEncodedUrlPath)"
+        if let query = request.url.query {
+            urlString += "?\(query)"
+        }
+        var request = request
+        request.url = URL(string: urlString)!
+        return request
     }
 
     static let s3PathAllowedCharacters = CharacterSet.urlPathAllowed.subtracting(.init(charactersIn: "+@()&$=:,'!*"))
     /// percent encode path value.
-    private static func urlEncodePath(_ value: String) -> String {
-        value.addingPercentEncoding(withAllowedCharacters: Self.s3PathAllowedCharacters) ?? value
+    private static func urlEncodePath(_ value: some StringProtocol) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: Self.s3PathAllowedCharacters) ?? String(value)
     }
 
     func createBucketFixup(request: inout AWSHTTPRequest, context: AWSMiddlewareContext) {

--- a/Sources/SotoCore/Middleware/Middleware/S3Middleware.swift
+++ b/Sources/SotoCore/Middleware/Middleware/S3Middleware.swift
@@ -111,7 +111,7 @@ public struct S3Middleware: AWSMiddlewareProtocol {
             // if host name contains amazonaws.com and bucket name doesn't contain a period do virtual address look up
         } else if isAmazonUrl || context.serviceConfig.options.contains(.s3ForceVirtualHost), !bucket.contains(".") {
             let pathsWithoutBucket = paths.dropFirst()  // bucket
-            urlPath = pathsWithoutBucket.first.flatMap { String($0) } ?? ""  //pathsWithoutBucket.joined(separator: "/")
+            urlPath = pathsWithoutBucket.first.flatMap { String($0) } ?? ""
 
             if hostComponents.first == bucket {
                 // Bucket name is part of host. No need to append bucket

--- a/Tests/SotoCoreTests/Doc/ARNTests.swift
+++ b/Tests/SotoCoreTests/Doc/ARNTests.swift
@@ -12,10 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6.0)
+
 import SotoCore
 import Testing
 
-#if compiler(>=6.0)
 struct ARNTests {
     @Test
     func testValidARNWithoutResourceType() throws {

--- a/Tests/SotoCoreTests/Doc/ARNTests.swift
+++ b/Tests/SotoCoreTests/Doc/ARNTests.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2017-2020 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import SotoCore
+import Testing
+
+#if compiler(>=6.0)
+struct ARNTests {
+    @Test
+    func testValidARNWithoutResourceType() throws {
+        let arn = try #require(ARN(string: "arn:aws:sns:us-east-1:123456789012:example-sns-topic-name"))
+        #expect(arn.partition == .aws)
+        #expect(arn.service == "sns")
+        #expect(arn.region == .useast1)
+        #expect(arn.accountId == "123456789012")
+        #expect(arn.resourceId == "example-sns-topic-name")
+        #expect(arn.resourceType == nil)
+    }
+
+    @Test(arguments: [
+        "arn:aws:ec2:us-west-1:123456789012:vpc/vpc-0e9801d129EXAMPLE",
+        "arn:aws:ec2:us-west-1:123456789012:vpc:vpc-0e9801d129EXAMPLE",
+    ])
+    func testValidARNWithoutWithResourceType(arnString: String) throws {
+        let arn = try #require(ARN(string: arnString))
+        #expect(arn.partition == .aws)
+        #expect(arn.service == "ec2")
+        #expect(arn.region == .uswest1)
+        #expect(arn.accountId == "123456789012")
+        #expect(arn.resourceId == "vpc-0e9801d129EXAMPLE")
+        #expect(arn.resourceType == "vpc")
+    }
+
+    @Test
+    func testValidARNWithoutRegion() throws {
+        let arn = try #require(ARN(string: "arn:aws:iam::123456789012:user/adam"))
+        #expect(arn.partition == .aws)
+        #expect(arn.service == "iam")
+        #expect(arn.region == nil)
+        #expect(arn.accountId == "123456789012")
+        #expect(arn.resourceId == "adam")
+        #expect(arn.resourceType == "user")
+    }
+
+    @Test
+    func testValidARNWithoutAccountID() throws {
+        let arn = try #require(ARN(string: "arn:aws:s3:::my_corporate_bucket/*"))
+        #expect(arn.partition == .aws)
+        #expect(arn.service == "s3")
+        #expect(arn.region == nil)
+        #expect(arn.accountId == nil)
+        #expect(arn.resourceId == "*")
+        #expect(arn.resourceType == "my_corporate_bucket")
+    }
+
+}
+#endif

--- a/Tests/SotoCoreTests/MiddlewareTests.swift
+++ b/Tests/SotoCoreTests/MiddlewareTests.swift
@@ -184,7 +184,24 @@ class MiddlewareTests: XCTestCase {
         try await client.shutdown()
     }
 
-    func testS3MiddlewareArn() async throws {
+    func testS3MiddlewareAccessPointArn() async throws {
+        // Test virual address
+        try await self.testMiddleware(
+            S3Middleware(),
+            serviceName: "s3",
+            serviceOptions: .s3UseTransferAcceleratedEndpoint,
+            uri: "/arn:aws:s3:us-west-2:111122223333:accesspoint/test-accesspoint"
+        ) { request, context in
+            XCTAssertEqual(
+                request.url.absoluteString,
+                "https://test-accesspoint-111122223333.s3-accesspoint.us-west-2.amazonaws.com/"
+            )
+            XCTAssertEqual(context.serviceConfig.serviceIdentifier, "s3-accesspoint")
+            XCTAssertEqual(context.serviceConfig.region, .uswest2)
+        }
+    }
+
+    func testS3MiddlewareObjectLambdaArn() async throws {
         // Test virual address
         try await self.testMiddleware(
             S3Middleware(),

--- a/Tests/SotoCoreTests/MiddlewareTests.swift
+++ b/Tests/SotoCoreTests/MiddlewareTests.swift
@@ -20,6 +20,7 @@ import XCTest
 class MiddlewareTests: XCTestCase {
     struct CatchRequestError: Error {
         let request: AWSHTTPRequest
+        let context: AWSMiddlewareContext
     }
 
     struct CatchRequestMiddleware: AWSMiddlewareProtocol {
@@ -28,7 +29,7 @@ class MiddlewareTests: XCTestCase {
             context: AWSMiddlewareContext,
             next: (AWSHTTPRequest, AWSMiddlewareContext) async throws -> AWSHTTPResponse
         ) async throws -> AWSHTTPResponse {
-            throw CatchRequestError(request: request)
+            throw CatchRequestError(request: request, context: context)
         }
     }
 
@@ -37,7 +38,7 @@ class MiddlewareTests: XCTestCase {
         serviceName: String = "service",
         serviceOptions: AWSServiceConfig.Options = [],
         uri: String = "/",
-        test: (AWSHTTPRequest) -> Void
+        test: (AWSHTTPRequest, AWSMiddlewareContext) -> Void
     ) async throws {
         let client = createAWSClient(credentialProvider: .empty)
         let config = createServiceConfig(
@@ -54,7 +55,7 @@ class MiddlewareTests: XCTestCase {
             XCTFail("Should not get here")
         } catch {
             let error = try XCTUnwrap(error as? CatchRequestError)
-            test(error.request)
+            test(error.request, error.context)
         }
         try await client.shutdown()
     }
@@ -104,7 +105,7 @@ class MiddlewareTests: XCTestCase {
             .add(name: "testAdd", value: "testValue"),
             .add(name: "user-agent", value: "testEditHeaderMiddleware")
         )
-        try await self.testMiddleware(middleware) { request in
+        try await self.testMiddleware(middleware) { request, _ in
             XCTAssertEqual(request.headers["testAdd"].first, "testValue")
             XCTAssertEqual(request.headers["user-agent"].joined(separator: ","), "Soto/6.0,testEditHeaderMiddleware")
         }
@@ -115,15 +116,29 @@ class MiddlewareTests: XCTestCase {
         let middleware = AWSEditHeadersMiddleware(
             .replace(name: "user-agent", value: "testEditHeaderMiddleware")
         )
-        try await self.testMiddleware(middleware) { request in
+        try await self.testMiddleware(middleware) { request, _ in
             XCTAssertEqual(request.headers["user-agent"].first, "testEditHeaderMiddleware")
         }
     }
 
     func testS3MiddlewareVirtualAddress() async throws {
         // Test virual address
-        try await self.testMiddleware(S3Middleware(), uri: "/bucket/file") { request in
+        try await self.testMiddleware(S3Middleware(), uri: "/bucket/file") { request, _ in
             XCTAssertEqual(request.url.absoluteString, "https://bucket.service.us-east-1.amazonaws.com/file")
+        }
+    }
+
+    func testS3MiddlewareVirtualAddressWithSlash() async throws {
+        // Test virual address
+        try await self.testMiddleware(S3Middleware(), uri: "/bucket/file/sdf/") { request, _ in
+            XCTAssertEqual(request.url.absoluteString, "https://bucket.service.us-east-1.amazonaws.com/file/sdf/")
+        }
+    }
+
+    func testS3MiddlewareVirtualAddressWithPercentEncoding() async throws {
+        // Test virual address
+        try await self.testMiddleware(S3Middleware(), uri: "/bucket/file%26") { request, _ in
+            XCTAssertEqual(request.url.absoluteString, "https://bucket.service.us-east-1.amazonaws.com/file%26")
         }
     }
 
@@ -134,7 +149,7 @@ class MiddlewareTests: XCTestCase {
             serviceName: "s3",
             serviceOptions: .s3UseTransferAcceleratedEndpoint,
             uri: "/bucket/file"
-        ) { request in
+        ) { request, _ in
             XCTAssertEqual(request.url.absoluteString, "https://bucket.s3-accelerate.amazonaws.com/file")
         }
     }
@@ -167,6 +182,23 @@ class MiddlewareTests: XCTestCase {
             XCTFail("Throwing wrong error: \(error)")
         }
         try await client.shutdown()
+    }
+
+    func testS3MiddlewareArn() async throws {
+        // Test virual address
+        try await self.testMiddleware(
+            S3Middleware(),
+            serviceName: "s3",
+            serviceOptions: .s3UseTransferAcceleratedEndpoint,
+            uri: "/arn:aws:s3-object-lambda:us-west-2:111122223333:accesspoint/tutorial-object-lambda-accesspoint/file"
+        ) { request, context in
+            XCTAssertEqual(
+                request.url.absoluteString,
+                "https://tutorial-object-lambda-accesspoint-111122223333.s3-object-lambda.us-west-2.amazonaws.com/file"
+            )
+            XCTAssertEqual(context.serviceConfig.serviceIdentifier, "s3-object-lambda")
+            XCTAssertEqual(context.serviceConfig.region, .uswest2)
+        }
     }
 
     // create a buffer of random values. Will always create the same given you supply the same z and w values


### PR DESCRIPTION
You can set up an accesspoint using S3Control.
This PR adds support for using this arn as a bucket name.

This has been tested with S3 access points
In theory this should also work for S3 outposts and S3 object lambdas (thus resolving https://github.com/soto-project/soto/issues/611).