### PR TITLE
Add support for S3 express endpoints

### DIFF
--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -48,7 +48,7 @@ public final class AWSClient: Sendable {
     /// HTTP client used by AWSClient
     public let httpClient: AWSHTTPClient
     /// Logger used for non-request based output
-    let clientLogger: Logger
+    public let logger: Logger
     /// client options
     let options: Options
 
@@ -71,13 +71,13 @@ public final class AWSClient: Sendable {
         middleware: some AWSMiddlewareProtocol,
         options: Options = Options(),
         httpClient: AWSHTTPClient = HTTPClient.shared,
-        logger clientLogger: Logger = AWSClient.loggingDisabled
+        logger: Logger = AWSClient.loggingDisabled
     ) {
         self.httpClient = httpClient
         let credentialProvider = credentialProviderFactory.createProvider(
             context: .init(
                 httpClient: self.httpClient,
-                logger: clientLogger,
+                logger: logger,
                 options: options
             )
         )
@@ -88,7 +88,7 @@ public final class AWSClient: Sendable {
             RetryMiddleware(retryPolicy: retryPolicyFactory.retryPolicy)
             ErrorHandlingMiddleware(options: options)
         }
-        self.clientLogger = clientLogger
+        self.logger = logger
         self.options = options
     }
 
@@ -105,13 +105,13 @@ public final class AWSClient: Sendable {
         retryPolicy retryPolicyFactory: RetryPolicyFactory = .default,
         options: Options = Options(),
         httpClient: AWSHTTPClient = HTTPClient.shared,
-        logger clientLogger: Logger = AWSClient.loggingDisabled
+        logger: Logger = AWSClient.loggingDisabled
     ) {
         self.httpClient = httpClient
         let credentialProvider = credentialProviderFactory.createProvider(
             context: .init(
                 httpClient: self.httpClient,
-                logger: clientLogger,
+                logger: logger,
                 options: options
             )
         )
@@ -121,7 +121,7 @@ public final class AWSClient: Sendable {
             RetryMiddleware(retryPolicy: retryPolicyFactory.retryPolicy)
             ErrorHandlingMiddleware(options: options)
         }
-        self.clientLogger = clientLogger
+        self.logger = logger
         self.options = options
     }
 

--- a/Sources/SotoCore/AWSClient.swift
+++ b/Sources/SotoCore/AWSClient.swift
@@ -402,9 +402,15 @@ extension AWSClient {
             try Task.checkCancellation()
             // combine service and client middleware stacks
             let middlewareStack = config.middleware.map { AWSDynamicMiddlewareStack($0, self.middleware) } ?? self.middleware
+            let credential = try await self.credentialProvider.getCredential(logger: logger)
             let middlewareContext = AWSMiddlewareContext(
                 operation: operationName,
                 serviceConfig: config,
+                credential: StaticCredential(
+                    accessKeyId: credential.accessKeyId,
+                    secretAccessKey: credential.secretAccessKey,
+                    sessionToken: credential.sessionToken
+                ),
                 logger: logger
             )
             // run middleware stack with httpClient execute at the end

--- a/Sources/SotoCore/Credential/CredentialProvider.swift
+++ b/Sources/SotoCore/Credential/CredentialProvider.swift
@@ -170,7 +170,7 @@ extension CredentialProviderFactory {
     /// Don't supply any credentials
     public static var empty: CredentialProviderFactory {
         Self { _ in
-            StaticCredential(accessKeyId: "", secretAccessKey: "")
+            EmptyCredential()
         }
     }
 

--- a/Sources/SotoCore/Credential/EmptyCredential.swift
+++ b/Sources/SotoCore/Credential/EmptyCredential.swift
@@ -12,14 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SotoSignerV4
+/// Empty credentials
+public struct EmptyCredential: CredentialProvider, Credential {
+    public var accessKeyId: String { "" }
+    public var secretAccessKey: String { "" }
+    public var sessionToken: String? { nil }
 
-extension Credential {
-    func isEmpty() -> Bool {
-        self.accessKeyId.isEmpty || self.secretAccessKey.isEmpty
-    }
-
-    func getStaticCredential() -> StaticCredential {
-        .init(accessKeyId: accessKeyId, secretAccessKey: secretAccessKey, sessionToken: sessionToken)
+    public func getCredential(logger: Logger) async throws -> any Credential {
+        self
     }
 }

--- a/Sources/SotoCore/HTTP/AWSHTTPBody.swift
+++ b/Sources/SotoCore/HTTP/AWSHTTPBody.swift
@@ -74,6 +74,15 @@ public struct AWSHTTPBody: Sendable {
         }
     }
 
+    public var isEmpty: Bool {
+        switch self.storage {
+        case .byteBuffer(let buffer):
+            return buffer.readableBytes == 0
+        case .asyncSequence(_, let length):
+            return length == 0
+        }
+    }
+
     public var isStreaming: Bool {
         switch self.storage {
         case .byteBuffer:

--- a/Sources/SotoCore/Middleware/Middleware.swift
+++ b/Sources/SotoCore/Middleware/Middleware.swift
@@ -18,6 +18,7 @@ import Logging
 public struct AWSMiddlewareContext: Sendable {
     public var operation: String
     public var serviceConfig: AWSServiceConfig
+    public var credential: StaticCredential
     public var logger: Logger
 }
 

--- a/Sources/SotoCore/Middleware/Middleware/S3Middleware.swift
+++ b/Sources/SotoCore/Middleware/Middleware/S3Middleware.swift
@@ -68,60 +68,51 @@ public struct S3Middleware: AWSMiddlewareProtocol {
         if request.url.path.hasPrefix("/arn:") {
             return try await handleARNBucket(request, context: context, next: next)
         }
-        /// process URL into form ${bucket}.s3.amazon.com
+        /// split path into components. Drop first as it is an empty string
         let paths = request.url.path.split(separator: "/", maxSplits: 2, omittingEmptySubsequences: false).dropFirst()
         guard let bucket = paths.first, var host = request.url.host else { return try await next(request, context) }
+        let path = paths.dropFirst().first.flatMap { String($0) } ?? ""
 
         if let port = request.url.port {
             host = "\(host):\(port)"
         }
         var urlPath: String
         var urlHost: String
-        let isAmazonUrl = host.hasSuffix("amazonaws.com")
+        let isAmazonUrl = host.hasSuffix(context.serviceConfig.region.partition.dnsSuffix)
 
-        var hostComponents = host.split(separator: ".")
-        if isAmazonUrl, context.serviceConfig.options.contains(.s3UseTransferAcceleratedEndpoint) {
-            if let s3Index = hostComponents.firstIndex(where: { $0 == "s3" }) {
-                var s3 = "s3"
-                s3 += "-accelerate"
-                // assume next host component is region
-                let regionIndex = s3Index + 1
-                hostComponents.remove(at: regionIndex)
-                hostComponents[s3Index] = Substring(s3)
-                host = hostComponents.joined(separator: ".")
-            }
-        }
-
-        // Is bucket an ARN
-        if bucket.hasPrefix("arn:") {
-            guard let arn = ARN(string: bucket),
-                let resourceType = arn.resourceType,
-                let region = arn.region,
-                let accountId = arn.accountId
-            else {
-                throw AWSClient.ClientError.invalidARN
-            }
-            guard resourceType == "accesspoint", arn.service == "s3-object-lambda" || arn.service == "s3-outposts" else {
-                throw AWSClient.ClientError.invalidARN
-            }
-            urlPath = "/"
-            // https://tutorial-object-lambda-accesspoint-123456789012.s3-object-lambda.us-west-2.amazonaws.com:443
-            urlHost = "\(arn.resourceId)-\(resourceType)-\(accountId).\(arn.service).\(region).amazonaws.com"
-
-            // if host name contains amazonaws.com and bucket name doesn't contain a period do virtual address look up
-        } else if isAmazonUrl || context.serviceConfig.options.contains(.s3ForceVirtualHost), !bucket.contains(".") {
-            let pathsWithoutBucket = paths.dropFirst()  // bucket
-            urlPath = pathsWithoutBucket.first.flatMap { String($0) } ?? ""
-
-            if hostComponents.first == bucket {
-                // Bucket name is part of host. No need to append bucket
-                urlHost = host
-            } else {
-                urlHost = "\(bucket).\(host)"
-            }
-        } else {
-            urlPath = paths.joined(separator: "/")
+        // if bucket has suffix "-x-s3" then it must be an s3 express directory bucket and the endpoint needs set up
+        // to use s3express
+        if bucket.hasSuffix("--x-s3"), let host = getS3ExpressBucketEndpoint(bucket: bucket, path: path, context: context) {
             urlHost = host
+            urlPath = path
+        } else {
+
+            // Should we use accelerated endpoint
+            var hostComponents = host.split(separator: ".")
+            if isAmazonUrl, context.serviceConfig.options.contains(.s3UseTransferAcceleratedEndpoint) {
+                if let s3Index = hostComponents.firstIndex(where: { $0 == "s3" }) {
+                    var s3 = "s3"
+                    s3 += "-accelerate"
+                    // assume next host component is region
+                    let regionIndex = s3Index + 1
+                    hostComponents.remove(at: regionIndex)
+                    hostComponents[s3Index] = Substring(s3)
+                    host = hostComponents.joined(separator: ".")
+                }
+            }
+
+            if isAmazonUrl || context.serviceConfig.options.contains(.s3ForceVirtualHost), !bucket.contains(".") {
+                urlPath = path
+                if hostComponents.first == bucket {
+                    // Bucket name is part of host. No need to append bucket
+                    urlHost = host
+                } else {
+                    urlHost = "\(bucket).\(host)"
+                }
+            } else {
+                urlPath = paths.joined(separator: "/")
+                urlHost = host
+            }
         }
         let request = Self.updateRequestURL(request, host: urlHost, path: urlPath)
         return try await next(request, context)
@@ -155,7 +146,7 @@ public struct S3Middleware: AWSMiddlewareProtocol {
         let path = String(resourceIDSplit.dropFirst().first ?? "")
         let service = String(arn.service)
         let serviceIdentifier = service != "s3" ? service : "s3-accesspoint"
-        let urlHost = "\(bucket)-\(accountId).\(serviceIdentifier).\(region).amazonaws.com"
+        let urlHost = "\(bucket)-\(accountId).\(serviceIdentifier).\(region).\(context.serviceConfig.region.partition.dnsSuffix)"
         let request = Self.updateRequestURL(request, host: urlHost, path: path)
 
         var context = context
@@ -177,11 +168,29 @@ public struct S3Middleware: AWSMiddlewareProtocol {
         return try await next(request, context)
     }
 
+    ///  Handle bucket names in the form of an ARN
+    /// - Parameters:
+    ///   - request: request
+    ///   - context: request context
+    ///   - next: next handler
+    /// - Returns: returns response from next handler
+    func getS3ExpressBucketEndpoint(
+        bucket: Substring,
+        path: String,
+        context: AWSMiddlewareContext
+    ) -> String? {
+        // Note this uses my own version of split (as the Swift one requires macOS 13)
+        let split = bucket.split(separator: "--")
+        guard split.count > 2, split.last == "x-s3" else { return nil }
+        let zone = split[split.count - 2]
+        return "\(bucket).s3express-\(zone).\(context.serviceConfig.region).\(context.serviceConfig.region.partition.dnsSuffix)"
+    }
+
     ///  Update request with new host and path
     /// - Parameters:
     ///   - request: request
     ///   - host: new host name
-    ///   - path: new path
+    ///   - path: new path (without forward slash prefix)
     /// - Returns: new request
     static func updateRequestURL(_ request: AWSHTTPRequest, host: some StringProtocol, path: String) -> AWSHTTPRequest {
         var path = path
@@ -210,16 +219,18 @@ public struct S3Middleware: AWSMiddlewareProtocol {
         switch context.operation {
         // fixup CreateBucket to include location
         case "CreateBucket":
-            var xml = ""
-            if context.serviceConfig.region != .useast1 {
-                xml += "<CreateBucketConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
-                xml += "<LocationConstraint>"
-                xml += context.serviceConfig.region.rawValue
-                xml += "</LocationConstraint>"
-                xml += "</CreateBucketConfiguration>"
+            if request.body.isEmpty {
+                var xml = ""
+                if context.serviceConfig.region != .useast1 {
+                    xml += "<CreateBucketConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
+                    xml += "<LocationConstraint>"
+                    xml += context.serviceConfig.region.rawValue
+                    xml += "</LocationConstraint>"
+                    xml += "</CreateBucketConfiguration>"
+                }
+                // TODO: pass service config down so we can use the ByteBufferAllocator
+                request.body = .init(string: xml)
             }
-            // TODO: pass service config down so we can use the ByteBufferAllocator
-            request.body = .init(string: xml)
 
         default:
             break
@@ -261,5 +272,37 @@ public struct S3Middleware: AWSMiddlewareProtocol {
             }
         }
         return error
+    }
+}
+
+extension StringProtocol {
+    func split(separator: some StringProtocol) -> [Self.SubSequence] {
+        var split: [Self.SubSequence] = []
+        var index: Self.Index = self.startIndex
+        var startSplit: Self.Index = self.startIndex
+        while index != self.endIndex {
+            if let end = self[index...].prefixEnd(separator) {
+                split.append(self[startSplit..<index])
+                startSplit = end
+                index = end
+            } else {
+                index = self.index(after: index)
+            }
+        }
+        split.append(self[startSplit..<index])
+        return split
+    }
+
+    func prefixEnd(_ prefix: some StringProtocol) -> Self.Index? {
+        var prefixIndex = prefix.startIndex
+        var index = self.startIndex
+        while prefixIndex != prefix.endIndex {
+            if self[index] != prefix[prefixIndex] {
+                return nil
+            }
+            index = self.index(after: index)
+            prefixIndex = prefix.index(after: prefixIndex)
+        }
+        return index
     }
 }

--- a/Sources/SotoCore/Middleware/Middleware/SigningMiddleware.swift
+++ b/Sources/SotoCore/Middleware/Middleware/SigningMiddleware.swift
@@ -24,10 +24,12 @@ struct SigningMiddleware: AWSMiddlewareProtocol {
     @inlinable
     func handle(_ request: AWSHTTPRequest, context: AWSMiddlewareContext, next: AWSMiddlewareNextHandler) async throws -> AWSHTTPResponse {
         var request = request
-        // get credentials
-        let credential = try await self.credentialProvider.getCredential(logger: context.logger)
         // construct signer
-        let signer = AWSSigner(credentials: credential, name: context.serviceConfig.signingName, region: context.serviceConfig.region.rawValue)
+        let signer = AWSSigner(
+            credentials: context.credential,
+            name: context.serviceConfig.signingName,
+            region: context.serviceConfig.region.rawValue
+        )
         request.signHeaders(signer: signer, serviceConfig: context.serviceConfig)
         return try await next(request, context)
     }

--- a/Tests/SotoCoreTests/AWSServiceTests.swift
+++ b/Tests/SotoCoreTests/AWSServiceTests.swift
@@ -129,7 +129,12 @@ class AWSServiceTests: XCTestCase {
         let service = TestService(client: client, config: createServiceConfig())
         let service2 = service.with(middleware: TestMiddleware())
         let request = AWSHTTPRequest(url: URL(string: "http://testurl.com")!, method: .GET, headers: [:], body: .init())
-        let context = AWSMiddlewareContext(operation: "TestURL", serviceConfig: service2.config, logger: TestEnvironment.logger)
+        let context = AWSMiddlewareContext(
+            operation: "TestURL",
+            serviceConfig: service2.config,
+            credential: EmptyCredential().getStaticCredential(),
+            logger: TestEnvironment.logger
+        )
         let response = try await service2.config.middleware!.handle(request, context: context) { request, _ in
             .init(status: .ok, headers: request.headers, body: request.body)
         }

--- a/Tests/SotoCoreTests/Credential/RuntimeSelectorCredentialProviderTests.swift
+++ b/Tests/SotoCoreTests/Credential/RuntimeSelectorCredentialProviderTests.swift
@@ -81,7 +81,7 @@ class RuntimeSelectorCredentialProviderTests: XCTestCase {
         XCTAssertEqual(credential.secretAccessKey, "")
         XCTAssertEqual(credential.sessionToken, nil)
         let internalProvider = try await (client.credentialProvider as? RuntimeSelectorCredentialProvider)?.getCredentialProviderTask()
-        XCTAssert(internalProvider is StaticCredential)
+        XCTAssert(internalProvider is EmptyCredential)
     }
 
     func testFoundSelectorWithOneProvider() async throws {
@@ -90,7 +90,7 @@ class RuntimeSelectorCredentialProviderTests: XCTestCase {
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
         let credential = try await client.credentialProvider.getCredential(logger: TestEnvironment.logger)
         XCTAssert(credential.isEmpty())
-        XCTAssert(client.credentialProvider is StaticCredential)
+        XCTAssert(client.credentialProvider is EmptyCredential)
     }
 
     func testECSProvider() async throws {
@@ -188,7 +188,6 @@ class RuntimeSelectorCredentialProviderTests: XCTestCase {
         defer { XCTAssertNoThrow(try client.syncShutdown()) }
         _ = try await client.credentialProvider.getCredential(logger: TestEnvironment.logger)
         let internalProvider = try await (client.credentialProvider as? RuntimeSelectorCredentialProvider)?.getCredentialProviderTask()
-        XCTAssert(internalProvider is StaticCredential)
-        XCTAssert((internalProvider as? StaticCredential)?.isEmpty() == true)
+        XCTAssert(internalProvider is EmptyCredential)
     }
 }

--- a/Tests/SotoCoreTests/MiddlewareTests.swift
+++ b/Tests/SotoCoreTests/MiddlewareTests.swift
@@ -223,10 +223,25 @@ class MiddlewareTests: XCTestCase {
         try await self.testMiddleware(
             S3Middleware(),
             serviceName: "s3",
-            serviceOptions: .s3UseTransferAcceleratedEndpoint,
             uri: "/s3express--bucket--use1-az6--x-s3/file"
         ) { request, _ in
             XCTAssertEqual(request.url.absoluteString, "https://s3express--bucket--use1-az6--x-s3.s3express-use1-az6.us-east-1.amazonaws.com/file")
+        }
+    }
+
+    func testS3MiddlewareS3ExpressControlEndpoint() async throws {
+        // Test virual address
+        try await S3Middleware.$executionContext.withValue(.init(useS3ExpressControlEndpoint: true)) {
+            try await self.testMiddleware(
+                S3Middleware(),
+                serviceName: "s3",
+                uri: "/s3express--bucket--use1-az6--x-s3/"
+            ) { request, _ in
+                XCTAssertEqual(
+                    request.url.absoluteString,
+                    "https://s3express-control.us-east-1.amazonaws.com/s3express--bucket--use1-az6--x-s3/"
+                )
+            }
         }
     }
 

--- a/Tests/SotoCoreTests/MiddlewareTests.swift
+++ b/Tests/SotoCoreTests/MiddlewareTests.swift
@@ -43,7 +43,7 @@ class MiddlewareTests: XCTestCase {
         let client = createAWSClient(credentialProvider: .empty)
         let config = createServiceConfig(
             region: .useast1,
-            endpoint: "https://\(serviceName).us-east-1.amazonaws.com",
+            service: serviceName,
             middlewares: AWSMiddlewareStack {
                 middleware
                 CatchRequestMiddleware()

--- a/Tests/SotoCoreTests/MiddlewareTests.swift
+++ b/Tests/SotoCoreTests/MiddlewareTests.swift
@@ -218,6 +218,18 @@ class MiddlewareTests: XCTestCase {
         }
     }
 
+    func testS3MiddlewareS3ExpressEndpoint() async throws {
+        // Test virual address
+        try await self.testMiddleware(
+            S3Middleware(),
+            serviceName: "s3",
+            serviceOptions: .s3UseTransferAcceleratedEndpoint,
+            uri: "/s3express--bucket--use1-az6--x-s3/file"
+        ) { request, _ in
+            XCTAssertEqual(request.url.absoluteString, "https://s3express--bucket--use1-az6--x-s3.s3express-use1-az6.us-east-1.amazonaws.com/file")
+        }
+    }
+
     // create a buffer of random values. Will always create the same given you supply the same z and w values
     // Random number generator from https://www.codeproject.com/Articles/25172/Simple-Random-Number-Generation
     func createRandomBuffer(_ w: UInt, _ z: UInt, size: Int) -> [UInt8] {


### PR DESCRIPTION
- sets up the endpoint. It doesn't use the s3express signing process
- Adds credential to middleware context so that it can be accessed by s3 express middleware
- Add S3Middleware task local for settings specific to S3Middleware