### PR TITLE
Build on Swift 6.1 under macOS Static property 'dateFormatter' is not concurrency-safe

### DIFF
--- a/Sources/SotoCore/Encoder/CodableProperties/DateCoders.swift
+++ b/Sources/SotoCore/Encoder/CodableProperties/DateCoders.swift
@@ -109,7 +109,11 @@ public struct ISO8601DateCoder: CustomDecoder, CustomEncoder {
 /// Date coder for HTTP header format
 public struct HTTPHeaderDateCoder: DateFormatCoder {
     public static let format = "EEE, d MMM yyy HH:mm:ss z"
+    #if compiler(>=6.1)
+    nonisolated(unsafe) public static let dateFormatter = createDateFormatter()
+    #else
     public static let dateFormatter = createDateFormatter()
+    #endif
 }
 
 /// Unix Epoch Date coder


### PR DESCRIPTION
Avoid  build error on Swift 6.1 under macOS:

```
soto-core/Sources/SotoCore/Encoder/CodableProperties/DateCoders.swift:112:23 Static property 'dateFormatter' is not concurrency-safe because non-'Sendable' type 'DateFormatter' may have shared mutable state
```

Linux compiles fine.

Fixes https://github.com/soto-project/soto-core/issues/633