### PR TITLE
Add support for sigV4a signing

### DIFF
--- a/Sources/SotoSignerV4/HexEncoding.swift
+++ b/Sources/SotoSignerV4/HexEncoding.swift
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2025 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package struct HexEncoding<Base: Sequence> where Base.Element == UInt8 {
+    var base: Base
+
+    package init(_ base: Base) {
+        self.base = base
+    }
+}
+
+extension HexEncoding: Sequence {
+    package typealias Element = UInt8
+
+    package struct Iterator: IteratorProtocol {
+        package typealias Element = UInt8
+
+        var base: Base.Iterator
+        var _next: UInt8?
+
+        init(base: Base.Iterator) {
+            self.base = base
+            self._next = nil
+        }
+
+        package mutating func next() -> UInt8? {
+            switch self._next {
+            case .none:
+                guard let underlying = self.base.next() else {
+                    return nil
+                }
+                let first = underlying >> 4
+                let second = underlying & 0x0F
+                self._next = second.makeBase16Ascii()
+                return first.makeBase16Ascii()
+
+            case .some(let next):
+                self._next = nil
+                return next
+            }
+        }
+    }
+
+    package func makeIterator() -> Iterator {
+        Iterator(base: self.base.makeIterator())
+    }
+}
+
+extension HexEncoding: Collection where Base: Collection {
+    package struct Index: Comparable {
+        package static func < (lhs: HexEncoding<Base>.Index, rhs: HexEncoding<Base>.Index) -> Bool {
+            if lhs.base < rhs.base {
+                return true
+            } else if lhs.base > rhs.base {
+                return false
+            } else if lhs.first && !rhs.first {
+                return true
+            } else {
+                return false
+            }
+        }
+
+        var base: Base.Index
+        var first: Bool
+    }
+
+    package var startIndex: Index {
+        Index(base: self.base.startIndex, first: true)
+    }
+
+    package var endIndex: Index {
+        Index(base: self.base.endIndex, first: true)
+    }
+
+    package func index(after i: Index) -> Index {
+        if i.first {
+            return Index(base: i.base, first: false)
+        } else {
+            return Index(base: self.base.index(after: i.base), first: true)
+        }
+    }
+
+    package subscript(position: Index) -> UInt8 {
+        let value = self.base[position.base]
+        let base16 = position.first ? value >> 4 : value & 0x0F
+        return base16.makeBase16Ascii()
+    }
+}
+
+extension UInt8 {
+    func makeBase16Ascii() -> UInt8 {
+        assert(self < 16)
+        if self < 10 {
+            return self + UInt8(ascii: "0")
+        } else {
+            return self - 10 + UInt8(ascii: "a")
+        }
+    }
+}

--- a/Sources/SotoSignerV4/SigV4a.swift
+++ b/Sources/SotoSignerV4/SigV4a.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
-import Foundation
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import struct Foundation.Data
+#endif
 
 package struct SigV4aKeyPair {
 
@@ -139,110 +143,15 @@ extension [UInt8] {
             var digit = UInt32(self[index])
             digit += carry
             carry = (digit >> 8) & 0x01
+            // once carry is we will not have any further changes and we can exit early
+            if carry == 0 { return }
             self[index] = UInt8(digit & 0xFF)
         }
     }
 
-    package consuming func addingOne() -> [UInt8] {
+    fileprivate consuming func addingOne() -> [UInt8] {
         var new = consume self
         new.addOne()
         return new
-    }
-}
-
-package struct HexEncoding<Base: Sequence> where Base.Element == UInt8 {
-    var base: Base
-
-    package init(_ base: Base) {
-        self.base = base
-    }
-}
-
-extension HexEncoding: Sequence {
-    package typealias Element = UInt8
-
-    package struct Iterator: IteratorProtocol {
-        package typealias Element = UInt8
-
-        var base: Base.Iterator
-        var _next: UInt8?
-
-        init(base: Base.Iterator) {
-            self.base = base
-            self._next = nil
-        }
-
-        package mutating func next() -> UInt8? {
-            switch self._next {
-            case .none:
-                guard let underlying = self.base.next() else {
-                    return nil
-                }
-                let first = underlying >> 4
-                let second = underlying & 0x0F
-                self._next = second.makeBase16Ascii()
-                return first.makeBase16Ascii()
-
-            case .some(let next):
-                self._next = nil
-                return next
-            }
-        }
-    }
-
-    package func makeIterator() -> Iterator {
-        Iterator(base: self.base.makeIterator())
-    }
-}
-
-extension HexEncoding: Collection where Base: Collection {
-    package struct Index: Comparable {
-        package static func < (lhs: HexEncoding<Base>.Index, rhs: HexEncoding<Base>.Index) -> Bool {
-            if lhs.base < rhs.base {
-                return true
-            } else if lhs.base > rhs.base {
-                return false
-            } else if lhs.first && !rhs.first {
-                return true
-            } else {
-                return false
-            }
-        }
-
-        var base: Base.Index
-        var first: Bool
-    }
-
-    package var startIndex: Index {
-        Index(base: self.base.startIndex, first: true)
-    }
-
-    package var endIndex: Index {
-        Index(base: self.base.endIndex, first: true)
-    }
-
-    package func index(after i: Index) -> Index {
-        if i.first {
-            return Index(base: i.base, first: false)
-        } else {
-            return Index(base: self.base.index(after: i.base), first: true)
-        }
-    }
-
-    package subscript(position: Index) -> UInt8 {
-        let value = self.base[position.base]
-        let base16 = position.first ? value >> 4 : value & 0x0F
-        return base16.makeBase16Ascii()
-    }
-}
-
-extension UInt8 {
-    func makeBase16Ascii() -> UInt8 {
-        assert(self < 16)
-        if self < 10 {
-            return self + UInt8(ascii: "0")
-        } else {
-            return self - 10 + UInt8(ascii: "a")
-        }
     }
 }

--- a/Sources/SotoSignerV4/SigV4a.swift
+++ b/Sources/SotoSignerV4/SigV4a.swift
@@ -143,9 +143,10 @@ extension [UInt8] {
             var digit = UInt32(self[index])
             digit += carry
             carry = (digit >> 8) & 0x01
+            self[index] = UInt8(digit & 0xFF)
+
             // once carry is we will not have any further changes and we can exit early
             if carry == 0 { return }
-            self[index] = UInt8(digit & 0xFF)
         }
     }
 

--- a/Sources/SotoSignerV4/SigV4a.swift
+++ b/Sources/SotoSignerV4/SigV4a.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/SotoSignerV4/SigV4a.swift
+++ b/Sources/SotoSignerV4/SigV4a.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2025 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import Crypto
 import Foundation
 

--- a/Sources/SotoSignerV4/SigV4a.swift
+++ b/Sources/SotoSignerV4/SigV4a.swift
@@ -117,7 +117,7 @@ package struct SigV4aKeyPair {
     }
 }
 
-extension Array<UInt8> {
+extension [UInt8] {
 
     package mutating func addOne() {
         var carry: UInt32 = 1
@@ -194,7 +194,7 @@ extension HexEncoding: Collection where Base: Collection {
                 return false
             }
         }
-        
+
         var base: Base.Index
         var first: Bool
     }

--- a/Sources/SotoSignerV4/SigV4a.swift
+++ b/Sources/SotoSignerV4/SigV4a.swift
@@ -137,7 +137,7 @@ package struct SigV4aKeyPair {
 
 extension [UInt8] {
 
-    package mutating func addOne() {
+    fileprivate mutating func addOne() {
         var carry: UInt32 = 1
         for index in self.indices.reversed() {
             var digit = UInt32(self[index])
@@ -149,7 +149,7 @@ extension [UInt8] {
         }
     }
 
-    fileprivate consuming func addingOne() -> [UInt8] {
+    package consuming func addingOne() -> [UInt8] {
         var new = consume self
         new.addOne()
         return new

--- a/Sources/SotoSignerV4/SigV4a.swift
+++ b/Sources/SotoSignerV4/SigV4a.swift
@@ -1,0 +1,235 @@
+import Crypto
+import Foundation
+
+package struct SigV4aKeyPair {
+
+    package let key: P256.Signing.PrivateKey
+
+    package init(credential: some Credential) {
+        let secretBuffer = Self.makeSecretBuffer(credential: credential)
+        let secretKey = SymmetricKey(data: secretBuffer)
+
+        var counter: UInt8 = 1
+        while counter < Self.MAX_KEY_DERIVATION_COUNTER_VALUE {
+            defer { counter += 1 }
+
+            let inputBuffer = try! Self.makeFixedInputBuffer(credential: credential, counter: counter)
+
+            var hmac = HMAC<SHA256>(key: secretKey)
+            hmac.update(data: inputBuffer)
+            let digest = hmac.finalize()
+
+            let digestAsArray = [UInt8](digest)
+
+            switch try! Self.makeDerivedKey(bytes: digestAsArray) {
+            case .nextCounter:
+                continue
+
+            case .success(let key):
+                self.key = key
+                return
+            }
+        }
+
+        fatalError("Throw error here")
+    }
+
+    package func sign(_ string: String) throws -> String {
+        let signature = try self.key.signature(for: Data(string.utf8))
+        return signature.withUnsafeBytes {
+            String(decoding: HexEncoding($0), as: Unicode.UTF8.self)
+        }
+    }
+
+    private static let MAX_KEY_DERIVATION_COUNTER_VALUE = 254
+
+    static func makeFixedInputBuffer(credential: some Credential, counter: UInt8) throws -> [UInt8] {
+        if counter == 0 || counter > self.MAX_KEY_DERIVATION_COUNTER_VALUE {
+            throw SigV4aError.invalidCounterValue
+        }
+
+        var result = [UInt8]()
+        result.reserveCapacity(32 + credential.accessKeyId.utf8.count)
+        result.append(contentsOf: [0, 0, 0, 1])
+        result.append(contentsOf: "AWS4-ECDSA-P256-SHA256".utf8)
+        result.append(0)
+        result.append(contentsOf: credential.accessKeyId.utf8)
+        result.append(counter)
+        result.append(contentsOf: [0, 0, 1, 0])
+
+        return result
+    }
+
+    private static let SECRET_BUFFER_PREFIX = "AWS4A"
+
+    static func makeSecretBuffer(credential: some Credential) -> [UInt8] {
+        var result = [UInt8]()
+        result.reserveCapacity(credential.secretAccessKey.utf8.count + self.SECRET_BUFFER_PREFIX.utf8.count)
+        result.append(contentsOf: self.SECRET_BUFFER_PREFIX.utf8)
+        result.append(contentsOf: credential.secretAccessKey.utf8)
+        return result
+    }
+
+    package static func compareConstantTime(lhs: [UInt8], rhs: [UInt8]) -> Int8 {
+        guard lhs.count == rhs.count else {
+            fatalError("Input arrays must be of same size")
+        }
+
+        var gt: UInt8 = 0
+        var eq: UInt8 = 1
+        let length = lhs.count
+
+        for i in 0..<length {
+            let lhsDigit: Int32 = Int32(lhs[i])
+            let rhsDigit: Int32 = Int32(rhs[i])
+
+            gt |= UInt8(bitPattern: Int8((rhsDigit - lhsDigit) >> 31)) & eq
+            eq &= UInt8(bitPattern: Int8((((lhsDigit ^ rhsDigit) - 1) >> 31) & 0x01))
+        }
+
+        return Int8(gt) + Int8(gt) + Int8(eq) - 1
+    }
+
+    package enum DerivedKeyResult {
+        case success(P256.Signing.PrivateKey)
+        case nextCounter
+    }
+
+    private static let s_n_minus_2: [UInt8] = [
+        0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00,
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+        0xBC, 0xE6, 0xFA, 0xAD, 0xA7, 0x17, 0x9E, 0x84,
+        0xF3, 0xB9, 0xCA, 0xC2, 0xFC, 0x63, 0x25, 0x4F,
+    ]
+
+    package static func makeDerivedKey(bytes: [UInt8]) throws -> DerivedKeyResult {
+        assert(bytes.count == 32)
+
+        let comparisonResult = compareConstantTime(lhs: bytes, rhs: s_n_minus_2)
+        if comparisonResult > 0 {
+            return .nextCounter
+        }
+
+        return try .success(P256.Signing.PrivateKey(rawRepresentation: bytes.addingOne()))
+    }
+}
+
+enum SigV4aError: Error {
+    case invalidCounterValue
+}
+
+extension Array<UInt8> {
+
+    package mutating func addOne() {
+        var carry: UInt32 = 1
+        for index in self.indices.reversed() {
+            var digit = UInt32(self[index])
+            digit += carry
+            carry = (digit >> 8) & 0x01
+            self[index] = UInt8(digit & 0xFF)
+        }
+    }
+
+    package consuming func addingOne() -> [UInt8] {
+        var new = consume self
+        new.addOne()
+        return new
+    }
+}
+
+package struct HexEncoding<Base: Sequence> where Base.Element == UInt8 {
+    var base: Base
+
+    package init(_ base: Base) {
+        self.base = base
+    }
+}
+
+extension HexEncoding: Sequence {
+    package typealias Element = UInt8
+
+    package struct Iterator: IteratorProtocol {
+        package typealias Element = UInt8
+
+        var base: Base.Iterator
+        var _next: UInt8?
+
+        init(base: Base.Iterator) {
+            self.base = base
+            self._next = nil
+        }
+
+        package mutating func next() -> UInt8? {
+            switch self._next {
+            case .none:
+                guard let underlying = self.base.next() else {
+                    return nil
+                }
+                let first = underlying >> 4
+                let second = underlying & 0x0F
+                self._next = second.makeBase16Ascii()
+                return first.makeBase16Ascii()
+
+            case .some(let next):
+                self._next = nil
+                return next
+            }
+        }
+    }
+
+    package func makeIterator() -> Iterator {
+        Iterator(base: self.base.makeIterator())
+    }
+}
+
+extension HexEncoding: Collection where Base: Collection {
+    package struct Index: Comparable {
+        package static func < (lhs: HexEncoding<Base>.Index, rhs: HexEncoding<Base>.Index) -> Bool {
+            if lhs.base < rhs.base {
+                return true
+            } else if lhs.base > rhs.base {
+                return false
+            } else if lhs.first && !rhs.first {
+                return true
+            } else {
+                return false
+            }
+        }
+        
+        var base: Base.Index
+        var first: Bool
+    }
+
+    package var startIndex: Index {
+        Index(base: self.base.startIndex, first: true)
+    }
+
+    package var endIndex: Index {
+        Index(base: self.base.endIndex, first: true)
+    }
+
+    package func index(after i: Index) -> Index {
+        if i.first {
+            return Index(base: i.base, first: false)
+        } else {
+            return Index(base: self.base.index(after: i.base), first: true)
+        }
+    }
+
+    package subscript(position: Index) -> UInt8 {
+        let value = self.base[position.base]
+        let base16 = position.first ? value >> 4 : value & 0x0F
+        return base16.makeBase16Ascii()
+    }
+}
+
+extension UInt8 {
+    func makeBase16Ascii() -> UInt8 {
+        assert(self < 16)
+        if self < 10 {
+            return self + UInt8(ascii: "0")
+        } else {
+            return self - 10 + UInt8(ascii: "a")
+        }
+    }
+}

--- a/Sources/SotoSignerV4/SigV4a.swift
+++ b/Sources/SotoSignerV4/SigV4a.swift
@@ -35,8 +35,11 @@ package struct SigV4aKeyPair {
     }
 
     package func sign(_ string: String) throws -> String {
-        let signature = try self.key.signature(for: Data(string.utf8))
-        return signature.withUnsafeBytes {
+        // we want to be explcit about using SHA256 as the hash method
+        let digest = SHA256.hash(data: Data(string.utf8))
+        let signature = try self.key.signature(for: digest)
+
+        return signature.derRepresentation.withUnsafeBytes {
             String(decoding: HexEncoding($0), as: Unicode.UTF8.self)
         }
     }

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -466,17 +466,18 @@ public struct AWSSigner: Sendable {
         }
     }
 
+    // Stage 3a Calculating signature as in https://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
     func signV4(_ signingData: SigningData) -> String {
         let signingKey = self.signingKey(date: signingData.date)
         let kSignature = HMAC<SHA256>.authenticationCode(for: [UInt8](self.stringToSign(signingData: signingData, algorithm: .sigV4).utf8), using: signingKey)
         return kSignature.hexDigest()
     }
 
-    // Stage 3a Calculating signature as in https://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
     func signV4a(_ signingData: SigningData) -> String {
         let signingKey = SigV4aKeyPair(credential: self.credentials)
         let stringToSign = self.stringToSign(signingData: signingData, algorithm: .sigV4a)
-        return try! signingKey.sign(stringToSign)
+        let signature = try! signingKey.sign(stringToSign)
+        return signature
     }
 
     /// Stage 2 Create the string to sign as in https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -184,12 +184,13 @@ public struct AWSSigner: Sendable {
             signer: self
         )
 
-        let credential = switch algorithm.base {
-        case .sigV4:
-            "\(self.credentials.accessKeyId)/\(signingData.date)/\(self.region)/\(self.name)/aws4_request"
-        case .sigV4a:
-            "\(self.credentials.accessKeyId)/\(signingData.date)/\(self.name)/aws4_request"
-        }
+        let credential =
+            switch algorithm.base {
+            case .sigV4:
+                "\(self.credentials.accessKeyId)/\(signingData.date)/\(self.region)/\(self.name)/aws4_request"
+            case .sigV4a:
+                "\(self.credentials.accessKeyId)/\(signingData.date)/\(self.name)/aws4_request"
+            }
 
         // construct authorization string
         let authorization =
@@ -374,7 +375,7 @@ public struct AWSSigner: Sendable {
 
         // construct authorization string
         let authorization =
-        "\(algorithm.name) " + "Credential=\(credentials.accessKeyId)/\(signingData.date)/\(self.region)/\(self.name)/aws4_request,"
+            "\(algorithm.name) " + "Credential=\(credentials.accessKeyId)/\(signingData.date)/\(self.region)/\(self.name)/aws4_request,"
             + "SignedHeaders=\(signingData.signedHeaders)," + "Signature=\(signature)"
 
         // add Authorization header
@@ -469,7 +470,10 @@ public struct AWSSigner: Sendable {
     // Stage 3a Calculating signature as in https://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
     func signV4(_ signingData: SigningData) -> String {
         let signingKey = self.signingKey(date: signingData.date)
-        let kSignature = HMAC<SHA256>.authenticationCode(for: [UInt8](self.stringToSign(signingData: signingData, algorithm: .sigV4).utf8), using: signingKey)
+        let kSignature = HMAC<SHA256>.authenticationCode(
+            for: [UInt8](self.stringToSign(signingData: signingData, algorithm: .sigV4).utf8),
+            using: signingKey
+        )
         return kSignature.hexDigest()
     }
 

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -196,8 +196,8 @@ public struct AWSSigner: Sendable {
         let authorization =
             """
             \(algorithm.name) \
-            Credential=\(credential), \
-            SignedHeaders=\(signingData.signedHeaders), \
+            Credential=\(credential),\
+            SignedHeaders=\(signingData.signedHeaders),\
             Signature=\(self.signature(signingData: signingData, algorithm: algorithm))
             """
 
@@ -241,7 +241,6 @@ public struct AWSSigner: Sendable {
             algorithm: .sigV4
         )
     }
-
 
     /// Generate a signed URL, for a HTTP request
     /// - Parameters:

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Soto for AWS open source project
 //
-// Copyright (c) 2017-2022 the Soto project authors
+// Copyright (c) 2017-2025 the Soto project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/SotoSignerV4Tests/SigV4aTests.swift
+++ b/Tests/SotoSignerV4Tests/SigV4aTests.swift
@@ -55,4 +55,11 @@ final class SigV4aTests: XCTestCase {
         XCTAssertEqual(String(decoding: HexEncoding(result.key.rawRepresentation), as: Unicode.UTF8.self), expectedPrivateKeyHex)
     }
 
+    func testHexEncoding() {
+        XCTAssertEqual(String(decoding: HexEncoding([0]), as: Unicode.UTF8.self), "00")
+        XCTAssertEqual(String(decoding: HexEncoding([1]), as: Unicode.UTF8.self), "01")
+        XCTAssertEqual(String(decoding: HexEncoding([254]), as: Unicode.UTF8.self), "fe")
+        XCTAssertEqual(String(decoding: HexEncoding([255]), as: Unicode.UTF8.self), "ff")
+        XCTAssertEqual(String(decoding: HexEncoding([254, 255, 0]), as: Unicode.UTF8.self), "feff00")
+    }
 }

--- a/Tests/SotoSignerV4Tests/SigV4aTests.swift
+++ b/Tests/SotoSignerV4Tests/SigV4aTests.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Soto for AWS open source project
+//
+// Copyright (c) 2025 the Soto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of Soto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import SotoSignerV4
 @_spi(SotoInternal) import SotoSignerV4
 import XCTest

--- a/Tests/SotoSignerV4Tests/SigV4aTests.swift
+++ b/Tests/SotoSignerV4Tests/SigV4aTests.swift
@@ -1,6 +1,6 @@
-import XCTest
 import SotoSignerV4
 @_spi(SotoInternal) import SotoSignerV4
+import XCTest
 
 final class SigV4aTests: XCTestCase {
 

--- a/Tests/SotoSignerV4Tests/SigV4aTests.swift
+++ b/Tests/SotoSignerV4Tests/SigV4aTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+import SotoSignerV4
+@_spi(SotoInternal) import SotoSignerV4
+
+final class SigV4aTests: XCTestCase {
+
+    func testCompareConstantTime() {
+
+        let lhs1: [UInt8] = [0x00, 0x00, 0x00]
+        let rhs1: [UInt8] = [0x00, 0x00, 0x01]
+        let lhs2: [UInt8] = [0xAB, 0xCD, 0x80, 0xFF, 0x01, 0x0A]
+        let rhs2: [UInt8] = [0xAB, 0xCD, 0x80, 0xFF, 0x01, 0x0A]
+        let lhs3: [UInt8] = [0xFF, 0xCD, 0x80, 0xFF, 0x01, 0x0A]
+        let rhs3: [UInt8] = [0xFE, 0xCD, 0x80, 0xFF, 0x01, 0x0A]
+
+        XCTAssertEqual(SigV4aKeyPair.compareConstantTime(lhs: lhs1, rhs: rhs1), -1)
+        XCTAssertEqual(SigV4aKeyPair.compareConstantTime(lhs: lhs2, rhs: rhs2), 0)
+        XCTAssertEqual(SigV4aKeyPair.compareConstantTime(lhs: lhs3, rhs: rhs3), 1)
+
+    }
+
+    func testAddOne() {
+        XCTAssertEqual([0x00, 0x00, 0x00].addingOne(), [0x00, 0x00, 0x01])
+        XCTAssertEqual([0x00, 0x00, 0xFF].addingOne(), [0x00, 0x01, 0x00])
+        XCTAssertEqual([0x00, 0xFF, 0xFF].addingOne(), [0x01, 0x00, 0x00])
+        XCTAssertEqual([0xFF, 0xFF, 0xFF, 0xFF].addingOne(), [0x00, 0x00, 0x00, 0x00])
+    }
+
+    func testDerivedStaticKey() {
+        let accessKey = "AKISORANDOMAASORANDOM"
+        let secretAccessKey = "q+jcrXGc+0zWN6uzclKVhvMmUsIfRPa4rlRandom"
+
+        let expectedPrivateKeyHex = "7fd3bd010c0d9c292141c2b77bfbde1042c92e6836fff749d1269ec890fca1bd"
+
+        let credential = StaticCredential(accessKeyId: accessKey, secretAccessKey: secretAccessKey)
+
+        let result = SigV4aKeyPair(credential: credential)
+        XCTAssertEqual(result.key.rawRepresentation.hexDigest(), expectedPrivateKeyHex)
+    }
+
+    func testDeriveLongKey() {
+        let accessKey = """
+            AKISORANDOMAASORANDOMFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF\
+            FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF\
+            FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFf
+            """
+        let secretAccessKey = "q+jcrXGc+0zWN6uzclKVhvMmUsIfRPa4rlRandom"
+
+        let expectedPrivateKeyHex = "bc0fd68955922f2cccd5c27f8aa04394a467ef1076d889b66569c6d2e764faf3"
+
+        let credential = StaticCredential(accessKeyId: accessKey, secretAccessKey: secretAccessKey)
+
+        let result = SigV4aKeyPair(credential: credential)
+        XCTAssertEqual(result.key.rawRepresentation.hexDigest(), expectedPrivateKeyHex)
+        XCTAssertEqual(String(decoding: HexEncoding(result.key.rawRepresentation), as: Unicode.UTF8.self), expectedPrivateKeyHex)
+    }
+
+}


### PR DESCRIPTION
- Tested signing manually against S3 for both query and header
- Writing a full test case is hard, as signing ECDSA signing is non deterministic
- Added new HexEncoding mode, that can be used to make `hexDigest()` much faster :)

Fixes: #532 