### PR TITLE
Don't apply S3 virtual address fixup if bucket is ""

### DIFF
--- a/Sources/SotoCore/Middleware/Middleware/S3Middleware.swift
+++ b/Sources/SotoCore/Middleware/Middleware/S3Middleware.swift
@@ -82,7 +82,7 @@ public struct S3Middleware: AWSMiddlewareProtocol {
         }
         /// split path into components. Drop first as it is an empty string
         let paths = request.url.path.split(separator: "/", maxSplits: 2, omittingEmptySubsequences: false).dropFirst()
-        guard let bucket = paths.first, var host = request.url.host else { return try await next(request, context) }
+        guard let bucket = paths.first, bucket != "", var host = request.url.host else { return try await next(request, context) }
         let path = paths.dropFirst().first.flatMap { String($0) } ?? ""
 
         if let port = request.url.port {

--- a/Tests/SotoCoreTests/MiddlewareTests.swift
+++ b/Tests/SotoCoreTests/MiddlewareTests.swift
@@ -121,6 +121,13 @@ class MiddlewareTests: XCTestCase {
         }
     }
 
+    func testS3MiddlewareNoBucket() async throws {
+        // Test virual address
+        try await self.testMiddleware(S3Middleware(), uri: "/") { request, _ in
+            XCTAssertEqual(request.url.absoluteString, "https://service.us-east-1.amazonaws.com/")
+        }
+    }
+
     func testS3MiddlewareVirtualAddress() async throws {
         // Test virual address
         try await self.testMiddleware(S3Middleware(), uri: "/bucket/file") { request, _ in


### PR DESCRIPTION
If URL `/` is passed in the split of the path returns a bucket name of "". This should be assumed to mean we have no bucket so don't do the S3 virtual address mixup.