### PR TITLE
Add ability to decode custom errors

### DIFF
--- a/Sources/SotoCore/Doc/AWSShape.swift
+++ b/Sources/SotoCore/Doc/AWSShape.swift
@@ -193,6 +193,9 @@ extension AWSEncodableShape {
 /// AWSShape that can be decoded from API output
 public protocol AWSDecodableShape: AWSShape & Decodable {}
 
+/// AWSShape that can be decoded as an error
+public protocol AWSErrorShape: AWSShape & Decodable {}
+
 /// AWSShape options.
 public struct AWSShapeOptions: OptionSet, Sendable {
     public var rawValue: Int

--- a/Sources/SotoCore/Errors/Error.swift
+++ b/Sources/SotoCore/Errors/Error.swift
@@ -36,8 +36,9 @@ extension AWSErrorType {
     }
 }
 
+/// Service that has extended error information
 public protocol AWSServiceErrorType: AWSErrorType {
-    static var errorCodeMap: [String: (Decodable & Error).Type] { get }
+    static var errorCodeMap: [String: AWSErrorShape.Type] { get }
 }
 
 /// Additional information about error
@@ -46,20 +47,20 @@ public struct AWSErrorContext {
     public let responseCode: HTTPResponseStatus
     public let headers: HTTPHeaders
     public let additionalFields: [String: String]
-    public let underlyingError: Error?
+    public let extendedError: AWSErrorShape?
 
     internal init(
         message: String,
         responseCode: HTTPResponseStatus,
         headers: HTTPHeaders = [:],
         additionalFields: [String: String] = [:],
-        underlyingError: Error? = nil
+        extendedError: AWSErrorShape? = nil
     ) {
         self.message = message
         self.responseCode = responseCode
         self.headers = headers
         self.additionalFields = additionalFields
-        self.underlyingError = underlyingError
+        self.extendedError = extendedError
     }
 }
 

--- a/Sources/SotoCore/Errors/Error.swift
+++ b/Sources/SotoCore/Errors/Error.swift
@@ -28,12 +28,16 @@ public protocol AWSErrorType: Error, CustomStringConvertible {
 
 extension AWSErrorType {
     public var localizedDescription: String {
-        description
+        "\(self)"
     }
 
     public var message: String? {
         context?.message
     }
+}
+
+public protocol AWSServiceErrorType: AWSErrorType {
+    static var errorCodeMap: [String: (Decodable & Error).Type] { get }
 }
 
 /// Additional information about error
@@ -42,17 +46,20 @@ public struct AWSErrorContext {
     public let responseCode: HTTPResponseStatus
     public let headers: HTTPHeaders
     public let additionalFields: [String: String]
+    public let underlyingError: Error?
 
     internal init(
         message: String,
         responseCode: HTTPResponseStatus,
         headers: HTTPHeaders = [:],
-        additionalFields: [String: String] = [:]
+        additionalFields: [String: String] = [:],
+        underlyingError: Error? = nil
     ) {
         self.message = message
         self.responseCode = responseCode
         self.headers = headers
         self.additionalFields = additionalFields
+        self.underlyingError = underlyingError
     }
 }
 

--- a/Sources/SotoCore/HTTP/AWSHTTPResponse.swift
+++ b/Sources/SotoCore/HTTP/AWSHTTPResponse.swift
@@ -201,7 +201,9 @@ public struct AWSHTTPResponse: Sendable {
         init(from decoder: Decoder) throws {
             // use `ErrorCodingKey` so we get extract additional keys from `container.allKeys`
             let container = try decoder.container(keyedBy: ErrorCodingKey.self)
-            self.code = try container.decodeIfPresent(String.self, forKey: .init("Code"))
+            let code = try container.decodeIfPresent(String.self, forKey: .init("Code"))
+            // Remove namespace from error code
+            self.code = code?.split(separator: "#").last.map { String($0) }
             self.message = try container.decode(String.self, forKey: .init("Message"))
 
             if let code = self.code,
@@ -234,12 +236,15 @@ public struct AWSHTTPResponse: Sendable {
         init(from decoder: Decoder) throws {
             // use `ErrorCodingKey` so we get extract additional keys from `container.allKeys`
             let container = try decoder.container(keyedBy: ErrorCodingKey.self)
-            self.code = try container.decodeIfPresent(String.self, forKey: .init("__type"))
+            let code = try container.decodeIfPresent(String.self, forKey: .init("__type"))
+            // Remove namespace from error code
+            self.code = code?.split(separator: "#").last.map { String($0) }
             self.message =
                 try container.decodeIfPresent(String.self, forKey: .init("message")) ?? container.decode(String.self, forKey: .init("Message"))
 
+            let errorMapping = decoder.userInfo[.awsErrorMap]
             if let code = self.code,
-                let errorMapping = decoder.userInfo[.awsErrorMap] as? AWSServiceErrorType.Type,
+                let errorMapping = errorMapping as? AWSServiceErrorType.Type,
                 let errorType = errorMapping.errorCodeMap[code]
             {
                 let container = try decoder.singleValueContainer()
@@ -268,7 +273,9 @@ public struct AWSHTTPResponse: Sendable {
         init(from decoder: Decoder) throws {
             // use `ErrorCodingKey` so we get extract additional keys from `container.allKeys`
             let container = try decoder.container(keyedBy: ErrorCodingKey.self)
-            self.code = try container.decodeIfPresent(String.self, forKey: .init("code"))
+            let code = try container.decodeIfPresent(String.self, forKey: .init("code"))
+            // Remove namespace from error code
+            self.code = code?.split(separator: "#").last.map { String($0) }
             self.message =
                 try container.decodeIfPresent(String.self, forKey: .init("message")) ?? container.decode(String.self, forKey: .init("Message"))
 

--- a/Sources/SotoCore/HTTP/AWSHTTPResponse.swift
+++ b/Sources/SotoCore/HTTP/AWSHTTPResponse.swift
@@ -195,7 +195,7 @@ public struct AWSHTTPResponse: Sendable {
         var code: String?
         let message: String
         let additionalFields: [String: String]
-        let underlyingError: (Error & Decodable)?
+        let extendedError: AWSErrorShape?
 
         init(from decoder: Decoder) throws {
             // use `ErrorCodingKey` so we get extract additional keys from `container.allKeys`
@@ -208,9 +208,9 @@ public struct AWSHTTPResponse: Sendable {
                 let errorType = errorMapping.errorCodeMap[code]
             {
                 let container = try decoder.singleValueContainer()
-                self.underlyingError = try? container.decode(errorType)
+                self.extendedError = try? container.decode(errorType)
             } else {
-                self.underlyingError = nil
+                self.extendedError = nil
             }
 
             var additionalFields: [String: String] = [:]
@@ -228,7 +228,7 @@ public struct AWSHTTPResponse: Sendable {
         var code: String?
         let message: String
         let additionalFields: [String: String]
-        let underlyingError: (Error & Decodable)?
+        let extendedError: AWSErrorShape?
 
         init(from decoder: Decoder) throws {
             // use `ErrorCodingKey` so we get extract additional keys from `container.allKeys`
@@ -242,9 +242,9 @@ public struct AWSHTTPResponse: Sendable {
                 let errorType = errorMapping.errorCodeMap[code]
             {
                 let container = try decoder.singleValueContainer()
-                self.underlyingError = try? container.decode(errorType)
+                self.extendedError = try? container.decode(errorType)
             } else {
-                self.underlyingError = nil
+                self.extendedError = nil
             }
             var additionalFields: [String: String] = [:]
             for key in container.allKeys {
@@ -262,7 +262,7 @@ public struct AWSHTTPResponse: Sendable {
         var code: String?
         let message: String
         let additionalFields: [String: String]
-        let underlyingError: (Error & Decodable)?
+        let extendedError: AWSErrorShape?
 
         init(from decoder: Decoder) throws {
             // use `ErrorCodingKey` so we get extract additional keys from `container.allKeys`
@@ -276,9 +276,9 @@ public struct AWSHTTPResponse: Sendable {
                 let errorType = errorMapping.errorCodeMap[code]
             {
                 let container = try decoder.singleValueContainer()
-                self.underlyingError = try? container.decode(errorType)
+                self.extendedError = try? container.decode(errorType)
             } else {
-                self.underlyingError = nil
+                self.extendedError = nil
             }
 
             var additionalFields: [String: String] = [:]
@@ -317,7 +317,7 @@ private protocol APIError {
     var code: String? { get set }
     var message: String { get }
     var additionalFields: [String: String] { get }
-    var underlyingError: (Error & Decodable)? { get }
+    var extendedError: AWSErrorShape? { get }
 }
 
 extension XML.Document {

--- a/Sources/SotoCore/HTTP/AWSHTTPResponse.swift
+++ b/Sources/SotoCore/HTTP/AWSHTTPResponse.swift
@@ -168,7 +168,8 @@ public struct AWSHTTPResponse: Sendable {
                 message: errorMessage.message,
                 responseCode: self.status,
                 headers: self.headers,
-                additionalFields: errorMessage.additionalFields
+                additionalFields: errorMessage.additionalFields,
+                extendedError: errorMessage.extendedError
             )
 
             if let errorType = serviceConfig.errorType {

--- a/Tests/SotoCoreTests/AWSResponseTests.swift
+++ b/Tests/SotoCoreTests/AWSResponseTests.swift
@@ -356,7 +356,7 @@ class AWSResponseTests: XCTestCase {
         XCTAssertEqual(error?.message, "Don't like it")
         XCTAssertEqual(error?.context?.responseCode, .notFound)
         XCTAssertEqual(error?.context?.additionalFields["fault"], "client")
-        let contextError = try XCTUnwrap(error?.context?.underlyingError as? ServiceErrorType.MessageRejected)
+        let contextError = try XCTUnwrap(error?.context?.extendedError as? ServiceErrorType.MessageRejected)
         XCTAssertEqual(contextError.fault, "client")
     }
 
@@ -675,7 +675,7 @@ class AWSResponseTests: XCTestCase {
     // MARK: Types used in tests
 
     struct ServiceErrorType: AWSServiceErrorType, Equatable {
-        struct MessageRejected: Error & Decodable {
+        struct MessageRejected: AWSErrorShape {
             let message: String?
             let fault: String?
         }
@@ -688,7 +688,7 @@ class AWSResponseTests: XCTestCase {
         let error: Code
         let context: AWSErrorContext?
 
-        static let errorCodeMap: [String: (Error & Decodable).Type] = ["MessageRejected": MessageRejected.self]
+        static let errorCodeMap: [String: AWSErrorShape.Type] = ["MessageRejected": MessageRejected.self]
 
         init?(errorCode: String, context: AWSErrorContext) {
             guard let error = Code(rawValue: errorCode) else { return nil }

--- a/Tests/SotoCoreTests/AWSResponseTests.swift
+++ b/Tests/SotoCoreTests/AWSResponseTests.swift
@@ -356,6 +356,8 @@ class AWSResponseTests: XCTestCase {
         XCTAssertEqual(error?.message, "Don't like it")
         XCTAssertEqual(error?.context?.responseCode, .notFound)
         XCTAssertEqual(error?.context?.additionalFields["fault"], "client")
+        let contextError = try XCTUnwrap(error?.context?.underlyingError as? ServiceErrorType.MessageRejected)
+        XCTAssertEqual(contextError.fault, "client")
     }
 
     func testEC2Error() async throws {
@@ -672,7 +674,11 @@ class AWSResponseTests: XCTestCase {
 
     // MARK: Types used in tests
 
-    struct ServiceErrorType: AWSErrorType, Equatable {
+    struct ServiceErrorType: AWSServiceErrorType, Equatable {
+        struct MessageRejected: Error & Decodable {
+            let message: String?
+            let fault: String?
+        }
         enum Code: String {
             case resourceNotFoundException = "ResourceNotFoundException"
             case noSuchKey = "NoSuchKey"
@@ -681,6 +687,8 @@ class AWSResponseTests: XCTestCase {
 
         let error: Code
         let context: AWSErrorContext?
+
+        static let errorCodeMap: [String: (Error & Decodable).Type] = ["MessageRejected": MessageRejected.self]
 
         init?(errorCode: String, context: AWSErrorContext) {
             guard let error = Code(rawValue: errorCode) else { return nil }


### PR DESCRIPTION
At the moment I have to attach an existential to the standard error to avoid a breaking change. If we ever release a 8.0 I'll look to throw concrete versions of these errors.

This is to support https://github.com/soto-project/soto/issues/761