### PR TITLE
Don't output body for json DELETE requests

### DIFF
--- a/Sources/SotoCore/HTTP/AWSHTTPRequest.swift
+++ b/Sources/SotoCore/HTTP/AWSHTTPRequest.swift
@@ -128,7 +128,8 @@ extension AWSHTTPRequest {
             encoder.userInfo[.awsRequest] = requestEncoderContainer
             encoder.dateEncodingStrategy = .secondsSince1970
             let buffer = try encoder.encodeAsByteBuffer(input, allocator: configuration.byteBufferAllocator)
-            if method == .GET || method == .HEAD, buffer == ByteBuffer(string: "{}") {
+            // GET, HEAD and DELETE methods should have an empty body
+            if method == .GET || method == .HEAD || method == .DELETE, buffer == ByteBuffer(string: "{}") {
                 body = .init()
             } else {
                 body = .init(buffer: buffer)
@@ -260,6 +261,8 @@ extension AWSHTTPRequest {
         guard self.headers["content-type"].first == nil else {
             return
         }
+        // in theory we don't need this check as the check for an empty body should skip adding
+        // a header and a GET or HEAD request should have an empty body
         guard self.method != .GET, self.method != .HEAD else {
             return
         }

--- a/Tests/SotoCoreTests/AWSRequestTests.swift
+++ b/Tests/SotoCoreTests/AWSRequestTests.swift
@@ -510,7 +510,7 @@ class AWSRequestTests: XCTestCase {
         XCTAssertEqual(request.headers["content-type"].first, "application/x-amz-json-1.0")
     }
 
-    /// JSON POST request require a body even if there is no data to POST
+    /// JSON GET, HEAD, DELETE requests should not output a body if it is empty ie `{}`
     func testEmptyGetJsonObject() throws {
         struct Input: AWSEncodableShape {}
         let input = Input()
@@ -518,6 +518,12 @@ class AWSRequestTests: XCTestCase {
         let request = try AWSHTTPRequest(operation: "Test", path: "/", method: .GET, input: input, configuration: config)
         XCTAssertEqual(request.body.asString(), "")
         XCTAssertNil(request.headers["content-type"].first)
+        let request2 = try AWSHTTPRequest(operation: "Test", path: "/", method: .HEAD, input: input, configuration: config)
+        XCTAssertEqual(request2.body.asString(), "")
+        XCTAssertNil(request2.headers["content-type"].first)
+        let request3 = try AWSHTTPRequest(operation: "Test", path: "/", method: .DELETE, input: input, configuration: config)
+        XCTAssertEqual(request3.body.asString(), "")
+        XCTAssertNil(request3.headers["content-type"].first)
     }
 
     /// Test host prefix

--- a/Tests/SotoCoreTests/AWSRequestTests.swift
+++ b/Tests/SotoCoreTests/AWSRequestTests.swift
@@ -501,13 +501,23 @@ class AWSRequestTests: XCTestCase {
     }
 
     /// JSON POST request require a body even if there is no data to POST
-    func testEmptyJsonObject() {
+    func testEmptyPostJsonObject() throws {
         struct Input: AWSEncodableShape {}
         let input = Input()
         let config = createServiceConfig(serviceProtocol: .json(version: "1.0"), endpoint: "https://test.com")
-        var request: AWSHTTPRequest?
-        XCTAssertNoThrow(request = try AWSHTTPRequest(operation: "Test", path: "/", method: .POST, input: input, configuration: config))
-        XCTAssertEqual(request?.body.asString(), "{}")
+        let request = try AWSHTTPRequest(operation: "Test", path: "/", method: .POST, input: input, configuration: config)
+        XCTAssertEqual(request.body.asString(), "{}")
+        XCTAssertEqual(request.headers["content-type"].first, "application/x-amz-json-1.0")
+    }
+
+    /// JSON POST request require a body even if there is no data to POST
+    func testEmptyGetJsonObject() throws {
+        struct Input: AWSEncodableShape {}
+        let input = Input()
+        let config = createServiceConfig(serviceProtocol: .json(version: "1.0"), endpoint: "https://test.com")
+        let request = try AWSHTTPRequest(operation: "Test", path: "/", method: .GET, input: input, configuration: config)
+        XCTAssertEqual(request.body.asString(), "")
+        XCTAssertNil(request.headers["content-type"].first)
     }
 
     /// Test host prefix


### PR DESCRIPTION
HTTP DELETE methods should not include a body. We were only checking for GET and HEAD method requests previously. It wasn't an issue but AWS lambda is now returning a signing error because of this. So I've added a check for DELETE method in the serialisation of json bodies.

EDIT: Verified it fixes signing issue with deleting lambdas