### PR TITLE
Add spaces in Authorization header

### DIFF
--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -325,8 +325,8 @@ public struct AWSSigner: Sendable {
         let authorization =
             """
             \(algorithm.name) \
-            Credential=\(credentials.accessKeyId)/\(signingData.date)/\(self.region)/\(self.name)/aws4_request, \
-            SignedHeaders=\(signingData.signedHeaders), \
+            Credential=\(credentials.accessKeyId)/\(signingData.date)/\(self.region)/\(self.name)/aws4_request,\
+            SignedHeaders=\(signingData.signedHeaders),\
             Signature=\(signature))
             """
         // add Authorization header

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -177,8 +177,8 @@ public struct AWSSigner: Sendable {
         let authorization =
             """
             \(algorithm.name) \
-            Credential=\(credential), \
-            SignedHeaders=\(signingData.signedHeaders), \
+            Credential=\(credential),\
+            SignedHeaders=\(signingData.signedHeaders),\
             Signature=\(self.signature(signingData: signingData, algorithm: algorithm))
             """
 
@@ -323,12 +323,9 @@ public struct AWSSigner: Sendable {
 
         // construct authorization string
         let authorization =
-            """
-            \(algorithm.name) \
-            Credential=\(credentials.accessKeyId)/\(signingData.date)/\(self.region)/\(self.name)/aws4_request,\
-            SignedHeaders=\(signingData.signedHeaders),\
-            Signature=\(signature))
-            """
+            "\(algorithm.name) " + "Credential=\(credentials.accessKeyId)/\(signingData.date)/\(self.region)/\(self.name)/aws4_request, "
+            + "SignedHeaders=\(signingData.signedHeaders), " + "Signature=\(signature)"
+
         // add Authorization header
         headers.add(name: "authorization", value: authorization)
 

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -177,8 +177,8 @@ public struct AWSSigner: Sendable {
         let authorization =
             """
             \(algorithm.name) \
-            Credential=\(credential),\
-            SignedHeaders=\(signingData.signedHeaders),\
+            Credential=\(credential), \
+            SignedHeaders=\(signingData.signedHeaders), \
             Signature=\(self.signature(signingData: signingData, algorithm: algorithm))
             """
 

--- a/Sources/SotoSignerV4/signer.swift
+++ b/Sources/SotoSignerV4/signer.swift
@@ -177,8 +177,8 @@ public struct AWSSigner: Sendable {
         let authorization =
             """
             \(algorithm.name) \
-            Credential=\(credential),\
-            SignedHeaders=\(signingData.signedHeaders),\
+            Credential=\(credential), \
+            SignedHeaders=\(signingData.signedHeaders), \
             Signature=\(self.signature(signingData: signingData, algorithm: algorithm))
             """
 
@@ -323,9 +323,12 @@ public struct AWSSigner: Sendable {
 
         // construct authorization string
         let authorization =
-            "\(algorithm.name) " + "Credential=\(credentials.accessKeyId)/\(signingData.date)/\(self.region)/\(self.name)/aws4_request,"
-            + "SignedHeaders=\(signingData.signedHeaders)," + "Signature=\(signature)"
-
+            """
+            \(algorithm.name) \
+            Credential=\(credentials.accessKeyId)/\(signingData.date)/\(self.region)/\(self.name)/aws4_request, \
+            SignedHeaders=\(signingData.signedHeaders), \
+            Signature=\(signature))
+            """
         // add Authorization header
         headers.add(name: "authorization", value: authorization)
 

--- a/Tests/SotoSignerV4Tests/AWSSignerTests.swift
+++ b/Tests/SotoSignerV4Tests/AWSSignerTests.swift
@@ -54,7 +54,7 @@ final class AWSSignerTests: XCTestCase {
         )
         XCTAssertEqual(
             headers["Authorization"].first,
-            "AWS4-HMAC-SHA256 Credential=MYACCESSKEY/20010124/us-east-1/glacier/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-glacier-version,Signature=acfa9b03fca6b098d7b88bfd9bbdb4687f5b34e944a9c6ed9f4814c1b0b06d62"
+            "AWS4-HMAC-SHA256 Credential=MYACCESSKEY/20010124/us-east-1/glacier/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-glacier-version, Signature=acfa9b03fca6b098d7b88bfd9bbdb4687f5b34e944a9c6ed9f4814c1b0b06d62"
         )
     }
 
@@ -67,7 +67,7 @@ final class AWSSignerTests: XCTestCase {
         )
         XCTAssertEqual(
             headers["Authorization"].first,
-            "AWS4-HMAC-SHA256 Credential=MYACCESSKEY/20010124/eu-central-1/sns/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=9c04ae96a2ce8addfa7ce933bf7ddda342f42476bd8cef057d1d25f09fb059c1"
+            "AWS4-HMAC-SHA256 Credential=MYACCESSKEY/20010124/eu-central-1/sns/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=9c04ae96a2ce8addfa7ce933bf7ddda342f42476bd8cef057d1d25f09fb059c1"
         )
     }
 
@@ -82,7 +82,7 @@ final class AWSSignerTests: XCTestCase {
         )
         XCTAssertEqual(
             headers["Authorization"].first,
-            "AWS4-HMAC-SHA256 Credential=MYACCESSKEY/20010101/eu-west-1/sns/aws4_request,SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date,Signature=1d29943055a8ad094239e8de06082100f2426ebbb2c6a5bbcbb04c63e6a3f274"
+            "AWS4-HMAC-SHA256 Credential=MYACCESSKEY/20010101/eu-west-1/sns/aws4_request, SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=1d29943055a8ad094239e8de06082100f2426ebbb2c6a5bbcbb04c63e6a3f274"
         )
     }
 
@@ -140,7 +140,7 @@ final class AWSSignerTests: XCTestCase {
         )
         XCTAssertEqual(
             headers["Authorization"].first,
-            "AWS4-HMAC-SHA256 Credential=MYACCESSKEY/20010124/us-east-1/glacier/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-glacier-version,Signature=acfa9b03fca6b098d7b88bfd9bbdb4687f5b34e944a9c6ed9f4814c1b0b06d62"
+            "AWS4-HMAC-SHA256 Credential=MYACCESSKEY/20010124/us-east-1/glacier/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-glacier-version, Signature=acfa9b03fca6b098d7b88bfd9bbdb4687f5b34e944a9c6ed9f4814c1b0b06d62"
         )
     }
 
@@ -279,7 +279,7 @@ final class AWSSignerTests: XCTestCase {
         )
         XCTAssertEqual(
             signedHeaders["authorization"].first,
-            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;range;x-amz-content-sha256;x-amz-date,Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41"
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;range;x-amz-content-sha256;x-amz-date, Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41"
         )
     }
 
@@ -299,7 +299,7 @@ final class AWSSignerTests: XCTestCase {
         )
         XCTAssertEqual(
             signedHeaders["authorization"].first,
-            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class,Signature=98ad721746da40c64f1a55b78f14c238d841ea1380cd77a1b5971af0ece108bd"
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=date;host;x-amz-content-sha256;x-amz-date;x-amz-storage-class, Signature=98ad721746da40c64f1a55b78f14c238d841ea1380cd77a1b5971af0ece108bd"
         )
     }
 
@@ -313,7 +313,7 @@ final class AWSSignerTests: XCTestCase {
         )
         XCTAssertEqual(
             signedHeaders["authorization"].first,
-            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=fea454ca298b7da1c68078a5d1bdbfbbe0d65c699e0f91ac7a200a0136783543"
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=fea454ca298b7da1c68078a5d1bdbfbbe0d65c699e0f91ac7a200a0136783543"
         )
     }
 
@@ -327,7 +327,7 @@ final class AWSSignerTests: XCTestCase {
         )
         XCTAssertEqual(
             signedHeaders["authorization"].first,
-            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request,SignedHeaders=host;x-amz-content-sha256;x-amz-date,Signature=34b48302e7b5fa45bde8084f4b7868a86f0a534bc59db6670ed5711ef69dc6f7"
+            "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=34b48302e7b5fa45bde8084f4b7868a86f0a534bc59db6670ed5711ef69dc6f7"
         )
     }
 }


### PR DESCRIPTION
As reported in #655 OpenSearchServerless expects spaces in the Authorization header
I verified that aws-cli also adds spaces in between the sections of the Authorization header as well.