### PR TITLE
Adding Android support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,17 @@ jobs:
       with:
         files: info.lcov
         token: ${{ secrets.CODECOV_TOKEN }}
+  android:
+    name: Android
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+      - name: "Build for Android"
+        uses: skiptools/swift-android-action@v2
+        with:
+          build-tests: true
+          run-tests: false

--- a/Sources/SotoCore/Doc/Environment.swift
+++ b/Sources/SotoCore/Doc/Environment.swift
@@ -18,6 +18,8 @@ import Glibc
 import Musl
 #elseif canImport(Darwin)
 import Darwin.C
+#elseif canImport(Android)
+import Android
 #else
 #error("Unsupported platform")
 #endif

--- a/Sources/SotoTestUtils/Environment.swift
+++ b/Sources/SotoTestUtils/Environment.swift
@@ -18,6 +18,8 @@ import Glibc
 import Musl
 #elseif canImport(Darwin)
 import Darwin.C
+#elseif canImport(Android)
+import Android
 #else
 #error("Unsupported platform")
 #endif

--- a/Sources/SotoXML/Expat.swift
+++ b/Sources/SotoXML/Expat.swift
@@ -30,6 +30,8 @@ import Glibc
 import Musl
 #elseif canImport(Darwin)
 import Darwin.C
+#elseif canImport(Android)
+import Android
 #else
 #error("Unsupported platform")
 #endif

--- a/Tests/SotoCoreTests/Credential/StaticCredential+EnvironmentTests.swift
+++ b/Tests/SotoCoreTests/Credential/StaticCredential+EnvironmentTests.swift
@@ -22,6 +22,8 @@ import Glibc
 import Musl
 #elseif canImport(Darwin)
 import Darwin.C
+#elseif canImport(Android)
+import Android
 #else
 #error("Unsupported platform")
 #endif


### PR DESCRIPTION
### Goals ⚽

The goal of this pull request is to add Android support to soto-core.

The following changes were verified on the swift-6.1 toolchain built for
Android.

### Implementation Details 🚧
soto-core should work flawlessly against an android swift toolchain
(tested with version 6.1) with the same limitations and context as the
current support on Linux + Windows.


### Testing Details 🔍
No new unit tests were added.

tested on android api level 30
---------