### PR TITLE
Use jmespath.swift from jmespath org

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.7.2"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.13.1"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.23.0"),
-        .package(url: "https://github.com/adam-fowler/jmespath.swift.git", from: "1.0.2"),
+        .package(url: "https://github.com/jmespath/jmespath.swift.git", from: "1.0.2"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
My swift implementation of jmespath has moved to the official jmespath org. Lets use it